### PR TITLE
Fix and up to 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+- Fix downgrade analysis failed.
+
 ## 0.0.3
 
 - Update pubspec.yaml file.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  image: 4.1.0
+  image: ^4.1.0
   meta: ">=1.16.0 <2.0.0"
 description: "'A pure Dart implementation of Canvas API compatible with dart:ui.'"
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  image: ^4.0.0
+  image: 4.1.0
   meta: ">=1.16.0 <2.0.0"
 description: "'A pure Dart implementation of Canvas API compatible with dart:ui.'"
 dev_dependencies:
@@ -17,4 +17,4 @@ topics:
   - canvas
   - pure-dart
   - ui
-version: 0.0.3
+version: 0.0.4


### PR DESCRIPTION
0/20 points: Compatible with dependency constraint lower bounds
downgrade analysis failed failed with 2 errors:

UNDEFINED_NAMED_PARAMETER - lib/src/canvas/rendering_implementations.dart:205:9 - The named parameter 'antialias' isn't defined.
UNDEFINED_METHOD - lib/src/image.dart:41:26 - The method 'getBytes' isn't defined for the type 'Image'.

Run dart pub downgrade and then dart analyze to reproduce the above problem.