### PR TITLE
Switchable dart:ui / pure_ui backend architecture

### DIFF
--- a/.github/workflows/switching_architecture.yml
+++ b/.github/workflows/switching_architecture.yml
@@ -1,0 +1,61 @@
+name: Switching Architecture (Dart-only)
+
+# Fast, Flutter-free CI for the dart:ui <-> pure_ui switching architecture.
+# Covers the interface, the pure_ui backend adapter, the wrapper, and the
+# backend-agnostic conformance suite. The Flutter-only `dart_ui_adapter`
+# package is intentionally excluded (it needs the Flutter SDK).
+
+on:
+  push:
+    branches:
+      - main
+      - monorepo
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  dart:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Resolve workspace
+        run: dart pub get
+
+      - name: Analyze
+        run: |
+          for pkg in dart_ui_interface pure_ui_adapter dart_ui_wrapper dart_ui_conformance; do
+            echo "== analyze $pkg =="
+            (cd packages/$pkg && dart analyze)
+          done
+
+      - name: Format check
+        run: |
+          dart format --set-exit-if-changed \
+            packages/dart_ui_interface \
+            packages/pure_ui_adapter \
+            packages/dart_ui_wrapper \
+            packages/dart_ui_conformance
+
+      - name: Test
+        run: |
+          for pkg in dart_ui_interface pure_ui_adapter dart_ui_conformance; do
+            echo "== test $pkg =="
+            (cd packages/$pkg && dart test)
+          done
+
+      - name: Forbid direct dart:ui import outside dart_ui_adapter (plan §6.3)
+        run: |
+          if grep -rEn "^[[:space:]]*import 'dart:ui'" \
+            packages/dart_ui_interface/lib \
+            packages/pure_ui_adapter/lib \
+            packages/dart_ui_wrapper/lib \
+            packages/dart_ui_conformance/lib; then
+            echo "::error::dart:ui must only be imported by dart_ui_adapter"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -24,6 +24,37 @@ Pure UI is a Canvas API implemented in pure Dart without Flutter dependencies. I
 - **✍️ Text Rendering**: Full `ParagraphBuilder` / `Canvas.drawParagraph()` pipeline powered by TTF font parsing
 - **⚡ Server-Side Ready**: Image generation for web servers and batch processing
 
+## Switchable backend architecture (`dart:ui` ↔ `pure_ui`)
+
+This repository is a melos monorepo. Alongside `pure_ui`, it ships a
+backend-switching layer that lets the **same drawing code** run on either the
+Flutter engine (`dart:ui`) or `pure_ui`, selected by swapping one backend
+instance — no import changes required.
+
+| Package | Flutter | Role |
+|---|:---:|---|
+| `dart_ui_interface` | ✗ | value types, enums, `UiBackend`, abstract resource types |
+| `pure_ui_adapter` | ✗ | `PureUiBackend` (default, non-Flutter) |
+| `dart_ui_wrapper` | ✗ | `ui.dart` drop-in surface + switch API |
+| `dart_ui_adapter` | ✔ | `DartUiBackend` (Flutter engine) |
+| `dart_ui_conformance` | dev | backend-agnostic parity tests |
+
+```dart
+import 'package:dart_ui_wrapper/dart_ui_wrapper.dart';
+import 'package:dart_ui_wrapper/ui.dart' as ui;
+
+void main() {
+  installPureUiBackend(); // or: UiBackend.instance = const DartUiBackend();
+  final r = ui.PictureRecorder();
+  ui.Canvas(r, const ui.Rect.fromLTWH(0, 0, 100, 100))
+      .drawCircle(const ui.Offset(50, 50), 40, ui.Paint()..color = const ui.Color(0xFF2196F3));
+}
+```
+
+See [`docs/switching_architecture.md`](docs/switching_architecture.md) and
+[`docs/api_inventory.md`](docs/api_inventory.md) for the full design and
+coverage status. `pure_ui` itself remains an unchanged standalone drop-in.
+
 ## Migrating from dart:ui
 
 Migrating Flutter Canvas code to Pure UI requires minimal changes:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,37 @@ See [`docs/switching_architecture.md`](docs/switching_architecture.md) and
 [`docs/api_inventory.md`](docs/api_inventory.md) for the full design and
 coverage status. `pure_ui` itself remains an unchanged standalone drop-in.
 
+### Use cases
+
+The point of swapping one backend instead of one import is that the **same
+drawing code runs in two worlds** — the Flutter engine on device, and plain
+Dart everywhere else. That unlocks:
+
+- **Server-side / serverless image generation.** Render OG share images,
+  certificates, tickets, invoices/receipts, charts, QR-with-branding, or PDF
+  page bitmaps from a Dart backend or cloud function — no Flutter engine, no
+  headless browser. Use `dart:ui` in the app and `pure_ui` on the server with
+  one codebase.
+- **Write-once rendering libraries.** Ship a charting / diagram / signature-pad
+  / barcode package that draws identically for Flutter consumers (`dart:ui`)
+  and pure-Dart consumers (CLI, server) without forking the rendering code.
+- **Fast, engine-free golden tests.** Run your painting logic under plain
+  `dart test` by selecting `PureUiBackend` (optionally scoped with
+  `UiBackend.runWith`), instead of the slower `flutter test` + engine. Great
+  for CI and deterministic, reproducible snapshots.
+- **Batch / offline rendering pipelines.** Pre-generate thumbnails, sprite
+  atlases, map tiles, or report pages in a build step or worker isolate, then
+  ship the PNGs.
+- **Gradual migration & dual-target code.** Move existing Flutter `Canvas`
+  code behind `dart_ui_wrapper` once; afterwards you switch engines by changing
+  a single line at startup, not your imports.
+
+| You want to… | Backend | How |
+|---|---|---|
+| Draw on screen in a Flutter app | `dart:ui` | `UiBackend.instance = const DartUiBackend();` |
+| Generate images on a server / CLI | `pure_ui` | `installPureUiBackend();` |
+| Golden-test painting without Flutter | `pure_ui` | `UiBackend.runWith(const PureUiBackend(), () { … });` |
+
 ## Migrating from dart:ui
 
 Migrating Flutter Canvas code to Pure UI requires minimal changes:

--- a/docs/api_inventory.md
+++ b/docs/api_inventory.md
@@ -1,0 +1,84 @@
+# API Inventory & Coverage (P0 audit)
+
+Status of the `dart:ui` ↔ `pure_ui` switching architecture
+(see `pure_ui_switching_architecture_plan.md`). This is the P0 audit
+deliverable and the running coverage tracker.
+
+## Target versions (plan §11 resolution)
+
+| Item | Decision |
+|---|---|
+| Flutter (for `dart_ui_adapter`) | `>=3.0.0` (mise pins 3.44.2 for dev) |
+| Dart SDK | `^3.5.0` (workspace tooling needs 3.6+, root pins `>=3.11.0`) |
+| `Color` model | Wide-gamut: `Color.from`, `withValues`, double `a/r/g/b` channels (matches current pure_ui) |
+| `pure_ui` ↔ interface coupling | **Adapter** (`pure_ui_adapter`), not direct `implements` — keeps pure_ui's standalone drop-in untouched (plan §2.1 option, §6.0) |
+| Switch granularity | Global default **and** `Zone` scope (`UiBackend.runWith`) |
+| Package names | `dart_ui_interface` / `dart_ui_wrapper` / `dart_ui_adapter` / `pure_ui_adapter` / `dart_ui_conformance` |
+
+## Packages
+
+| Package | Flutter | Role | State |
+|---|:---:|---|---|
+| `dart_ui_interface` | ✗ | value types, enums, `UiBackend`, abstract resource types, top-level fns | ✅ implemented + tested |
+| `pure_ui_adapter` | ✗ | `PureUiBackend` (adapts pure_ui) | ✅ implemented + tested |
+| `dart_ui_wrapper` | ✗ | `ui.dart` drop-in surface + switch API | ✅ implemented |
+| `dart_ui_adapter` | ✔ | `DartUiBackend` (adapts `dart:ui`) | ⚠️ implemented, **untested here** (needs Flutter SDK) |
+| `dart_ui_conformance` | dev | backend-agnostic parity tests | ✅ green on pure_ui backend |
+
+## Coverage matrix
+
+Legend: ✅ routed through `UiBackend` and conformance-tested · 🟡 defined but not
+yet wired · ⛔ out of scope / `UnsupportedError`.
+
+### Value types (interface layer, concrete, `const` preserved — §1.3)
+`Offset` ✅ · `Size` ✅ · `Rect` ✅ · `RRect` ✅ · `Radius` ✅ · `Color` ✅
+· `RSTransform` 🟡 · `RSuperellipse` 🟡
+
+### Enums (interface layer, explicit mapping — §4.2)
+`BlendMode` ✅ · `PaintingStyle` ✅ · `StrokeCap` ✅ · `StrokeJoin` ✅ ·
+`BlurStyle` 🟡 · `FilterQuality` ✅ · `Clip` 🟡 · `ClipOp` ✅ ·
+`PathFillType` ✅ · `PathOperation` 🟡 · `VertexMode` 🟡 · `PointMode` ✅ ·
+`TileMode` 🟡 · `PixelFormat` ✅ · `ImageByteFormat` ✅
+
+### Resource types (abstract + factory dispatch — §4.3)
+| Type | State |
+|---|---|
+| `Paint` | ✅ all getters/setters pure_ui supports |
+| `Path` | ✅ moveTo/lineTo/curves/arc/add*/contains/bounds/shift/transform |
+| `Canvas` | ✅ draw{Rect,RRect,DRRect,Oval,Circle,Arc,Line,Path,Image,ImageRect,Points,Color,Paint,Picture}, save/restore/transform/clip* |
+| `PictureRecorder` | ✅ |
+| `Picture` | ✅ toImage/toImageSync/dispose |
+| `Image` | ✅ width/height/clone/isCloneOf/toByteData/dispose |
+| `Shader` / `Gradient` / `ImageShader` | 🟡 (horizontal expansion) |
+| `ColorFilter` / `ImageFilter` / `MaskFilter` | 🟡 |
+| `FragmentProgram` / `FragmentShader` | ⛔ pure_ui throws `UnsupportedError` |
+| `ParagraphBuilder` / `Paragraph` / `TextStyle` / `ParagraphStyle` / `StrutStyle` | 🟡 (text vertical slice next) |
+| `Vertices` / `PathMetric(s)` / `Tangent` | 🟡 |
+| `Codec` / `FrameInfo` / `ImageDescriptor` / `ImmutableBuffer` | 🟡 |
+
+### Top-level functions (§4.4)
+`lerpDouble` ✅ · `clampDouble` ✅ · `decodeImageFromPixels` ✅ (backend) ·
+`instantiateImageCodec` / `decodeImageFromList` 🟡
+
+### Out of scope (§4.5)
+`PlatformDispatcher`, `FlutterView`, `window`, `Display`, `Semantics*`,
+`PointerData*`, `KeyData`, `ChannelBuffers`.
+
+## pure_ui current coverage (audit notes)
+
+`pure_ui` already mirrors `dart:ui` closely: it ships an internal abstract /
+concrete split (`Canvas`/`_PureDartCanvas`, `Path`/`_PureDartPath`,
+`Picture`, `PictureRecorder`, `Codec`, `ImageDescriptor`) plus concrete
+`Paint`, `Image`, full text pipeline (`Paragraph*`, TTF shaping/layout) and
+`Gradient`/`Shader`/`ImageShader`. `FragmentProgram`/`FragmentShader` exist as
+stubs over `NativeFieldWrapperClass1`. The wide-gamut `Color` is already in
+place. This made the **adapter** approach low-risk: the interface mirrors
+`dart:ui`, and `pure_ui_adapter` translates value types at the boundary only.
+
+## Next steps (plan §12 horizontal expansion)
+1. Text vertical slice: `ParagraphBuilder` → `Paragraph` → `Canvas.drawParagraph`.
+2. Image codecs (`instantiateImageCodec`, `Codec`, `FrameInfo`).
+3. Shaders / filters (`Gradient`, `ImageShader`, `ColorFilter`, `ImageFilter`).
+4. Run conformance under Flutter against `DartUiBackend`; add golden tests
+   with tolerance (§7.2).
+5. CI lint: forbid direct `import 'dart:ui'` outside `dart_ui_adapter` (§6.3).

--- a/docs/switching_architecture.md
+++ b/docs/switching_architecture.md
@@ -1,0 +1,109 @@
+# Switchable `dart:ui` / `pure_ui` architecture
+
+Implementation of `pure_ui_switching_architecture_plan.md`. The goal: write
+drawing code once and run it on either the Flutter engine (`dart:ui`) or the
+pure-Dart `pure_ui`, switching backend **without changing imports** — just by
+swapping one backend instance.
+
+## Package layout
+
+```
+packages/
+  dart_ui_interface/    # contract: value types, enums, UiBackend, abstract types   (no Flutter)
+  pure_ui_adapter/      # PureUiBackend — adapts pure_ui                              (no Flutter)
+  dart_ui_wrapper/      # ui.dart drop-in surface + switch API; default = pure_ui     (no Flutter)
+  dart_ui_adapter/      # DartUiBackend — adapts dart:ui                              (Flutter only)
+  dart_ui_conformance/  # backend-agnostic parity tests                              (dev)
+  pure_ui/              # existing pure-Dart engine (unchanged; still a drop-in)
+```
+
+Dependency direction (no cycles):
+
+```
+app (Flutter) ─▶ dart_ui_wrapper ─▶ dart_ui_interface ◀─ pure_ui_adapter ─▶ pure_ui
+app (Flutter) ─▶ dart_ui_adapter ─▶ dart_ui_interface
+                 dart_ui_adapter ─▶ dart:ui (Flutter)
+app (CLI)     ─▶ dart_ui_wrapper (default pure_ui backend)
+```
+
+Flutter is isolated to `dart_ui_adapter` only (plan §1.2). `dart_ui_adapter`
+is intentionally **excluded from the Dart workspace** (see root `pubspec.yaml`
+`workspace:` list and melos `ignore:`) so that `dart pub get` / Dart-only CI
+never need the Flutter SDK.
+
+## Three coexisting usage modes (§6.0)
+
+| Mode | import | backend setup |
+|---|---|---|
+| Flutter native | `import 'dart:ui'` | — |
+| pure_ui standalone drop-in | `import 'package:pure_ui/pure_ui.dart'` | none |
+| switchable | `import 'package:dart_ui_wrapper/ui.dart' as ui` | choose a backend once |
+
+`pure_ui` itself is untouched, so mode 2 keeps working exactly as before.
+
+## Usage
+
+### Non-Flutter (CLI / server / tests)
+```dart
+import 'package:dart_ui_wrapper/dart_ui_wrapper.dart';
+import 'package:dart_ui_wrapper/ui.dart' as ui;
+
+void main() {
+  installPureUiBackend(); // default backend; call once
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder, const ui.Rect.fromLTWH(0, 0, 100, 100));
+  canvas.drawCircle(const ui.Offset(50, 50), 40, ui.Paint()..color = const ui.Color(0xFF2196F3));
+  // ...
+}
+```
+
+### Flutter (switch to the engine backend)
+```dart
+import 'package:dart_ui_interface/dart_ui_interface.dart';
+import 'package:dart_ui_adapter/dart_ui_adapter.dart';
+
+void main() {
+  UiBackend.instance = const DartUiBackend(); // route to dart:ui
+  runApp(const MyApp());
+}
+```
+
+### Scoped switch (e.g. isolate a golden render to pure_ui)
+```dart
+UiBackend.runWith(const PureUiBackend(), () {
+  // Paint(), Canvas(...), ... all resolve to pure_ui here, even on Flutter.
+});
+```
+
+## Design rules honoured
+
+- **Value types are concrete & `const`** in the interface layer; never routed
+  through factory dispatch (§1.3). Only resource-holding types dispatch.
+- **One type layer**: abstract type + factory + contract all live in
+  `dart_ui_interface`; backends only `implements` them (§1.4).
+- **Enums map explicitly** with exhaustive switches, never by `index` (§4.2).
+- **Unsupported features throw** `UnsupportedError` rather than silent no-op
+  (§5); `UiBackend.supports(BackendFeature)` reports capability.
+- **Not pixel-exact** across backends; conformance asserts API behaviour and
+  stable values (e.g. ARGB32), not bit-identical floats (§1.5).
+
+## Testing
+
+```bash
+# fast, Flutter-free path
+dart test packages/dart_ui_interface
+dart test packages/pure_ui_adapter
+dart test packages/dart_ui_conformance     # parity suite on PureUiBackend
+
+# dart:ui path (requires Flutter)
+cd packages/dart_ui_adapter && flutter test  # run the same parity suite on DartUiBackend
+```
+
+## Status
+
+Implemented and green (Flutter-free): the drawing vertical slice
+(`Paint`/`Path`/`Canvas`/`PictureRecorder`/`Picture`/`Image`) end-to-end,
+the backend switch mechanism (global + zone), and the pure_ui drop-in
+regression guard. `DartUiBackend` is implemented but unverified in this
+environment (no Flutter SDK). See `docs/api_inventory.md` for the full
+coverage matrix and the horizontal-expansion backlog (text, codecs, shaders).

--- a/packages/dart_ui_adapter/README.md
+++ b/packages/dart_ui_adapter/README.md
@@ -1,0 +1,42 @@
+# dart_ui_adapter
+
+Adapts Flutter's engine-provided `dart:ui` to the
+[`dart_ui_interface`](../dart_ui_interface) `UiBackend` contract, providing
+`DartUiBackend`.
+
+This is the **only** package in the switching architecture that depends on
+Flutter (plan §1.2). For that reason it is **excluded from the Dart pub
+workspace** (see the root `pubspec.yaml` `workspace:` list and the melos
+`ignore:` entry) so that the rest of the monorepo resolves and tests without a
+Flutter SDK.
+
+## Install in a Flutter app
+
+```dart
+import 'package:dart_ui_interface/dart_ui_interface.dart';
+import 'package:dart_ui_adapter/dart_ui_adapter.dart';
+
+void main() {
+  UiBackend.instance = const DartUiBackend();
+  runApp(const MyApp());
+}
+```
+
+## Run the conformance suite on this backend
+
+```bash
+cd packages/dart_ui_adapter
+flutter pub get
+flutter test
+```
+
+`test/conformance_test.dart` wires `DartUiBackend` and runs the same
+backend-agnostic suite from `dart_ui_conformance` that the pure_ui backend
+passes.
+
+## Notes / limitations
+
+- `createImageFromPixels` (synchronous) is unsupported on `dart:ui`, which only
+  exposes asynchronous `decodeImageFromPixels`; it throws `UnsupportedError`
+  per plan §5.
+- Cannot be analyzed or tested without the Flutter SDK present.

--- a/packages/dart_ui_adapter/lib/dart_ui_adapter.dart
+++ b/packages/dart_ui_adapter/lib/dart_ui_adapter.dart
@@ -1,0 +1,27 @@
+/// Adapts Flutter's engine-provided `dart:ui` to the [UiBackend] contract.
+///
+/// This is the only package in the switching architecture that depends on
+/// Flutter. A Flutter app installs it with:
+///
+/// ```dart
+/// import 'package:dart_ui_interface/dart_ui_interface.dart';
+/// import 'package:dart_ui_adapter/dart_ui_adapter.dart';
+///
+/// void main() {
+///   UiBackend.instance = const DartUiBackend();
+///   runApp(...);
+/// }
+/// ```
+library dart_ui_adapter;
+
+export 'package:dart_ui_interface/dart_ui_interface.dart';
+
+export 'src/backend.dart'
+    show
+        DartUiBackend,
+        DartUiPaint,
+        DartUiPath,
+        DartUiCanvas,
+        DartUiPicture,
+        DartUiPictureRecorder,
+        DartUiImage;

--- a/packages/dart_ui_adapter/lib/src/backend.dart
+++ b/packages/dart_ui_adapter/lib/src/backend.dart
@@ -1,0 +1,413 @@
+// DartUiBackend: adapts Flutter's engine-provided `dart:ui` types to the
+// interface contract. This is the only package in the architecture that
+// depends on Flutter (plan §1.2). It cannot be analyzed or tested without the
+// Flutter SDK.
+
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_ui_interface/dart_ui_interface.dart' as i;
+
+import 'conv.dart';
+
+/// A [i.UiBackend] backed by Flutter's `dart:ui` engine. Install it in a
+/// Flutter app's startup: `UiBackend.instance = DartUiBackend();`.
+class DartUiBackend implements i.UiBackend {
+  const DartUiBackend();
+
+  @override
+  String get name => 'dart:ui';
+
+  @override
+  bool supports(i.BackendFeature feature) => true;
+
+  @override
+  i.Paint createPaint() => DartUiPaint(ui.Paint());
+
+  @override
+  i.Path createPath() => DartUiPath(ui.Path());
+
+  @override
+  i.PictureRecorder createPictureRecorder() =>
+      DartUiPictureRecorder(ui.PictureRecorder());
+
+  @override
+  i.Canvas createCanvas(i.PictureRecorder recorder, [i.Rect? cullRect]) {
+    final ui.PictureRecorder raw = (recorder as DartUiPictureRecorder).raw;
+    final ui.Canvas canvas = cullRect == null
+        ? ui.Canvas(raw)
+        : ui.Canvas(raw, rectToUi(cullRect));
+    return DartUiCanvas(canvas);
+  }
+
+  @override
+  Future<i.Image> decodeImageFromPixels(
+    Uint8List pixels,
+    int width,
+    int height,
+    i.PixelFormat format,
+  ) {
+    final completer = Completer<i.Image>();
+    ui.decodeImageFromPixels(
+      pixels,
+      width,
+      height,
+      pixelFormatToUi(format),
+      (ui.Image image) => completer.complete(DartUiImage(image)),
+    );
+    return completer.future;
+  }
+
+  @override
+  i.Image createImageFromPixels(Uint8List pixels, int width, int height) {
+    // dart:ui only exposes asynchronous pixel decoding; there is no synchronous
+    // image-from-pixels constructor (plan §5: throw rather than silently no-op).
+    throw UnsupportedError(
+      'createImageFromPixels is not supported on the dart:ui backend; use '
+      'decodeImageFromPixels (async) instead.',
+    );
+  }
+}
+
+/// Wraps a `dart:ui` [ui.Paint].
+class DartUiPaint implements i.Paint {
+  DartUiPaint(this.raw);
+
+  final ui.Paint raw;
+
+  @override
+  i.BlendMode get blendMode => i.BlendMode.values[raw.blendMode.index];
+  @override
+  set blendMode(i.BlendMode value) => raw.blendMode = blendModeToUi(value);
+
+  @override
+  i.Color get color => colorFromUi(raw.color);
+  @override
+  set color(i.Color value) => raw.color = colorToUi(value);
+
+  @override
+  i.FilterQuality get filterQuality => filterQualityFromUi(raw.filterQuality);
+  @override
+  set filterQuality(i.FilterQuality value) =>
+      raw.filterQuality = filterQualityToUi(value);
+
+  @override
+  bool get invertColors => raw.invertColors;
+  @override
+  set invertColors(bool value) => raw.invertColors = value;
+
+  @override
+  bool get isAntiAlias => raw.isAntiAlias;
+  @override
+  set isAntiAlias(bool value) => raw.isAntiAlias = value;
+
+  @override
+  i.StrokeCap get strokeCap => strokeCapFromUi(raw.strokeCap);
+  @override
+  set strokeCap(i.StrokeCap value) => raw.strokeCap = strokeCapToUi(value);
+
+  @override
+  i.StrokeJoin get strokeJoin => strokeJoinFromUi(raw.strokeJoin);
+  @override
+  set strokeJoin(i.StrokeJoin value) => raw.strokeJoin = strokeJoinToUi(value);
+
+  @override
+  double get strokeMiterLimit => raw.strokeMiterLimit;
+  @override
+  set strokeMiterLimit(double value) => raw.strokeMiterLimit = value;
+
+  @override
+  double get strokeWidth => raw.strokeWidth;
+  @override
+  set strokeWidth(double value) => raw.strokeWidth = value;
+
+  @override
+  i.PaintingStyle get style => paintingStyleFromUi(raw.style);
+  @override
+  set style(i.PaintingStyle value) => raw.style = paintingStyleToUi(value);
+}
+
+/// Wraps a `dart:ui` [ui.Path].
+class DartUiPath implements i.Path {
+  DartUiPath(this.raw);
+
+  final ui.Path raw;
+
+  @override
+  i.PathFillType get fillType => pathFillTypeFromUi(raw.fillType);
+  @override
+  set fillType(i.PathFillType value) => raw.fillType = pathFillTypeToUi(value);
+
+  @override
+  void moveTo(double x, double y) => raw.moveTo(x, y);
+  @override
+  void lineTo(double x, double y) => raw.lineTo(x, y);
+  @override
+  void relativeMoveTo(double dx, double dy) => raw.relativeMoveTo(dx, dy);
+  @override
+  void relativeLineTo(double dx, double dy) => raw.relativeLineTo(dx, dy);
+  @override
+  void quadraticBezierTo(double x1, double y1, double x2, double y2) =>
+      raw.quadraticBezierTo(x1, y1, x2, y2);
+  @override
+  void relativeQuadraticBezierTo(double x1, double y1, double x2, double y2) =>
+      raw.relativeQuadraticBezierTo(x1, y1, x2, y2);
+  @override
+  void cubicTo(
+    double x1,
+    double y1,
+    double x2,
+    double y2,
+    double x3,
+    double y3,
+  ) => raw.cubicTo(x1, y1, x2, y2, x3, y3);
+  @override
+  void relativeCubicTo(
+    double x1,
+    double y1,
+    double x2,
+    double y2,
+    double x3,
+    double y3,
+  ) => raw.relativeCubicTo(x1, y1, x2, y2, x3, y3);
+  @override
+  void conicTo(double x1, double y1, double x2, double y2, double w) =>
+      raw.conicTo(x1, y1, x2, y2, w);
+  @override
+  void relativeConicTo(double x1, double y1, double x2, double y2, double w) =>
+      raw.relativeConicTo(x1, y1, x2, y2, w);
+  @override
+  void arcTo(
+    i.Rect rect,
+    double startAngle,
+    double sweepAngle,
+    bool forceMoveTo,
+  ) => raw.arcTo(rectToUi(rect), startAngle, sweepAngle, forceMoveTo);
+  @override
+  void arcToPoint(
+    i.Offset arcEnd, {
+    i.Radius radius = i.Radius.zero,
+    double rotation = 0.0,
+    bool largeArc = false,
+    bool clockwise = true,
+  }) => raw.arcToPoint(
+    offsetToUi(arcEnd),
+    radius: radiusToUi(radius),
+    rotation: rotation,
+    largeArc: largeArc,
+    clockwise: clockwise,
+  );
+  @override
+  void addArc(i.Rect oval, double startAngle, double sweepAngle) =>
+      raw.addArc(rectToUi(oval), startAngle, sweepAngle);
+  @override
+  void addOval(i.Rect oval) => raw.addOval(rectToUi(oval));
+  @override
+  void addRect(i.Rect rect) => raw.addRect(rectToUi(rect));
+  @override
+  void addRRect(i.RRect rrect) => raw.addRRect(rrectToUi(rrect));
+  @override
+  void addPolygon(List<i.Offset> points, bool close) =>
+      raw.addPolygon(points.map(offsetToUi).toList(), close);
+  @override
+  void addPath(i.Path path, i.Offset offset, {Float64List? matrix4}) => raw
+      .addPath((path as DartUiPath).raw, offsetToUi(offset), matrix4: matrix4);
+  @override
+  void extendWithPath(i.Path path, i.Offset offset, {Float64List? matrix4}) =>
+      raw.extendWithPath(
+        (path as DartUiPath).raw,
+        offsetToUi(offset),
+        matrix4: matrix4,
+      );
+  @override
+  void close() => raw.close();
+  @override
+  void reset() => raw.reset();
+  @override
+  bool contains(i.Offset point) => raw.contains(offsetToUi(point));
+  @override
+  i.Rect getBounds() => rectFromUi(raw.getBounds());
+  @override
+  i.Path shift(i.Offset offset) => DartUiPath(raw.shift(offsetToUi(offset)));
+  @override
+  i.Path transform(Float64List matrix4) => DartUiPath(raw.transform(matrix4));
+}
+
+/// Wraps a `dart:ui` [ui.Canvas].
+class DartUiCanvas implements i.Canvas {
+  DartUiCanvas(this.raw);
+
+  final ui.Canvas raw;
+
+  ui.Paint _paint(i.Paint paint) => (paint as DartUiPaint).raw;
+
+  @override
+  void save() => raw.save();
+  @override
+  void saveLayer(i.Rect? bounds, i.Paint paint) =>
+      raw.saveLayer(bounds == null ? null : rectToUi(bounds), _paint(paint));
+  @override
+  void restore() => raw.restore();
+  @override
+  void restoreToCount(int count) => raw.restoreToCount(count);
+  @override
+  int getSaveCount() => raw.getSaveCount();
+  @override
+  void translate(double dx, double dy) => raw.translate(dx, dy);
+  @override
+  void scale(double sx, [double? sy]) => raw.scale(sx, sy);
+  @override
+  void rotate(double radians) => raw.rotate(radians);
+  @override
+  void skew(double sx, double sy) => raw.skew(sx, sy);
+  @override
+  void transform(Float64List matrix4) => raw.transform(matrix4);
+  @override
+  Float64List getTransform() => raw.getTransform();
+
+  @override
+  void clipRect(
+    i.Rect rect, {
+    i.ClipOp clipOp = i.ClipOp.intersect,
+    bool doAntiAlias = true,
+  }) => raw.clipRect(
+    rectToUi(rect),
+    clipOp: clipOpToUi(clipOp),
+    doAntiAlias: doAntiAlias,
+  );
+  @override
+  void clipRRect(i.RRect rrect, {bool doAntiAlias = true}) =>
+      raw.clipRRect(rrectToUi(rrect), doAntiAlias: doAntiAlias);
+  @override
+  void clipPath(i.Path path, {bool doAntiAlias = true}) =>
+      raw.clipPath((path as DartUiPath).raw, doAntiAlias: doAntiAlias);
+  @override
+  i.Rect getLocalClipBounds() => rectFromUi(raw.getLocalClipBounds());
+  @override
+  i.Rect getDestinationClipBounds() =>
+      rectFromUi(raw.getDestinationClipBounds());
+
+  @override
+  void drawColor(i.Color color, i.BlendMode blendMode) =>
+      raw.drawColor(colorToUi(color), blendModeToUi(blendMode));
+  @override
+  void drawPaint(i.Paint paint) => raw.drawPaint(_paint(paint));
+  @override
+  void drawLine(i.Offset p1, i.Offset p2, i.Paint paint) =>
+      raw.drawLine(offsetToUi(p1), offsetToUi(p2), _paint(paint));
+  @override
+  void drawRect(i.Rect rect, i.Paint paint) =>
+      raw.drawRect(rectToUi(rect), _paint(paint));
+  @override
+  void drawRRect(i.RRect rrect, i.Paint paint) =>
+      raw.drawRRect(rrectToUi(rrect), _paint(paint));
+  @override
+  void drawDRRect(i.RRect outer, i.RRect inner, i.Paint paint) =>
+      raw.drawDRRect(rrectToUi(outer), rrectToUi(inner), _paint(paint));
+  @override
+  void drawOval(i.Rect rect, i.Paint paint) =>
+      raw.drawOval(rectToUi(rect), _paint(paint));
+  @override
+  void drawCircle(i.Offset c, double radius, i.Paint paint) =>
+      raw.drawCircle(offsetToUi(c), radius, _paint(paint));
+  @override
+  void drawArc(
+    i.Rect rect,
+    double startAngle,
+    double sweepAngle,
+    bool useCenter,
+    i.Paint paint,
+  ) => raw.drawArc(
+    rectToUi(rect),
+    startAngle,
+    sweepAngle,
+    useCenter,
+    _paint(paint),
+  );
+  @override
+  void drawPath(i.Path path, i.Paint paint) =>
+      raw.drawPath((path as DartUiPath).raw, _paint(paint));
+  @override
+  void drawImage(i.Image image, i.Offset offset, i.Paint paint) => raw
+      .drawImage((image as DartUiImage).raw, offsetToUi(offset), _paint(paint));
+  @override
+  void drawImageRect(i.Image image, i.Rect src, i.Rect dst, i.Paint paint) =>
+      raw.drawImageRect(
+        (image as DartUiImage).raw,
+        rectToUi(src),
+        rectToUi(dst),
+        _paint(paint),
+      );
+  @override
+  void drawPoints(
+    i.PointMode pointMode,
+    List<i.Offset> points,
+    i.Paint paint,
+  ) => raw.drawPoints(
+    pointModeToUi(pointMode),
+    points.map(offsetToUi).toList(),
+    _paint(paint),
+  );
+  @override
+  void drawPicture(i.Picture picture) =>
+      raw.drawPicture((picture as DartUiPicture).raw);
+}
+
+/// Wraps a `dart:ui` [ui.PictureRecorder].
+class DartUiPictureRecorder implements i.PictureRecorder {
+  DartUiPictureRecorder(this.raw);
+
+  final ui.PictureRecorder raw;
+
+  @override
+  bool get isRecording => raw.isRecording;
+
+  @override
+  i.Picture endRecording() => DartUiPicture(raw.endRecording());
+}
+
+/// Wraps a `dart:ui` [ui.Picture].
+class DartUiPicture implements i.Picture {
+  DartUiPicture(this.raw);
+
+  final ui.Picture raw;
+
+  @override
+  int get approximateBytesUsed => raw.approximateBytesUsed;
+  @override
+  bool get debugDisposed => raw.debugDisposed;
+  @override
+  Future<i.Image> toImage(int width, int height) async =>
+      DartUiImage(await raw.toImage(width, height));
+  @override
+  i.Image toImageSync(int width, int height) =>
+      DartUiImage(raw.toImageSync(width, height));
+  @override
+  void dispose() => raw.dispose();
+}
+
+/// Wraps a `dart:ui` [ui.Image].
+class DartUiImage implements i.Image {
+  DartUiImage(this.raw);
+
+  final ui.Image raw;
+
+  @override
+  int get width => raw.width;
+  @override
+  int get height => raw.height;
+  @override
+  bool get debugDisposed => raw.debugDisposed;
+  @override
+  i.Image clone() => DartUiImage(raw.clone());
+  @override
+  bool isCloneOf(i.Image other) =>
+      other is DartUiImage && raw.isCloneOf(other.raw);
+  @override
+  Future<ByteData?> toByteData({
+    i.ImageByteFormat format = i.ImageByteFormat.rawRgba,
+  }) => raw.toByteData(format: imageByteFormatToUi(format));
+  @override
+  void dispose() => raw.dispose();
+}

--- a/packages/dart_ui_adapter/lib/src/conv.dart
+++ b/packages/dart_ui_adapter/lib/src/conv.dart
@@ -1,0 +1,257 @@
+// Value-type and enum conversions between the interface layer and dart:ui.
+//
+// Requires the Flutter SDK (for `dart:ui`). Conversions mirror those in
+// pure_ui_adapter but target engine types. Enums are mapped with explicit
+// switches (plan §4.2) — never by index.
+
+import 'dart:ui' as ui;
+
+import 'package:dart_ui_interface/dart_ui_interface.dart' as i;
+
+// --- value types ---
+
+ui.Offset offsetToUi(i.Offset o) => ui.Offset(o.dx, o.dy);
+i.Offset offsetFromUi(ui.Offset o) => i.Offset(o.dx, o.dy);
+
+ui.Size sizeToUi(i.Size s) => ui.Size(s.width, s.height);
+i.Size sizeFromUi(ui.Size s) => i.Size(s.width, s.height);
+
+ui.Rect rectToUi(i.Rect r) =>
+    ui.Rect.fromLTRB(r.left, r.top, r.right, r.bottom);
+i.Rect rectFromUi(ui.Rect r) =>
+    i.Rect.fromLTRB(r.left, r.top, r.right, r.bottom);
+
+ui.Radius radiusToUi(i.Radius r) => ui.Radius.elliptical(r.x, r.y);
+
+ui.RRect rrectToUi(i.RRect r) => ui.RRect.fromLTRBAndCorners(
+  r.left,
+  r.top,
+  r.right,
+  r.bottom,
+  topLeft: radiusToUi(r.tlRadius),
+  topRight: radiusToUi(r.trRadius),
+  bottomRight: radiusToUi(r.brRadius),
+  bottomLeft: radiusToUi(r.blRadius),
+);
+
+ui.Color colorToUi(i.Color c) =>
+    ui.Color.from(alpha: c.a, red: c.r, green: c.g, blue: c.b);
+i.Color colorFromUi(ui.Color c) =>
+    i.Color.from(alpha: c.a, red: c.r, green: c.g, blue: c.b);
+
+// --- enums ---
+
+ui.PaintingStyle paintingStyleToUi(i.PaintingStyle v) {
+  switch (v) {
+    case i.PaintingStyle.fill:
+      return ui.PaintingStyle.fill;
+    case i.PaintingStyle.stroke:
+      return ui.PaintingStyle.stroke;
+  }
+}
+
+i.PaintingStyle paintingStyleFromUi(ui.PaintingStyle v) {
+  switch (v) {
+    case ui.PaintingStyle.fill:
+      return i.PaintingStyle.fill;
+    case ui.PaintingStyle.stroke:
+      return i.PaintingStyle.stroke;
+  }
+}
+
+ui.StrokeCap strokeCapToUi(i.StrokeCap v) {
+  switch (v) {
+    case i.StrokeCap.butt:
+      return ui.StrokeCap.butt;
+    case i.StrokeCap.round:
+      return ui.StrokeCap.round;
+    case i.StrokeCap.square:
+      return ui.StrokeCap.square;
+  }
+}
+
+i.StrokeCap strokeCapFromUi(ui.StrokeCap v) {
+  switch (v) {
+    case ui.StrokeCap.butt:
+      return i.StrokeCap.butt;
+    case ui.StrokeCap.round:
+      return i.StrokeCap.round;
+    case ui.StrokeCap.square:
+      return i.StrokeCap.square;
+  }
+}
+
+ui.StrokeJoin strokeJoinToUi(i.StrokeJoin v) {
+  switch (v) {
+    case i.StrokeJoin.miter:
+      return ui.StrokeJoin.miter;
+    case i.StrokeJoin.round:
+      return ui.StrokeJoin.round;
+    case i.StrokeJoin.bevel:
+      return ui.StrokeJoin.bevel;
+  }
+}
+
+i.StrokeJoin strokeJoinFromUi(ui.StrokeJoin v) {
+  switch (v) {
+    case ui.StrokeJoin.miter:
+      return i.StrokeJoin.miter;
+    case ui.StrokeJoin.round:
+      return i.StrokeJoin.round;
+    case ui.StrokeJoin.bevel:
+      return i.StrokeJoin.bevel;
+  }
+}
+
+ui.FilterQuality filterQualityToUi(i.FilterQuality v) {
+  switch (v) {
+    case i.FilterQuality.none:
+      return ui.FilterQuality.none;
+    case i.FilterQuality.low:
+      return ui.FilterQuality.low;
+    case i.FilterQuality.medium:
+      return ui.FilterQuality.medium;
+    case i.FilterQuality.high:
+      return ui.FilterQuality.high;
+  }
+}
+
+i.FilterQuality filterQualityFromUi(ui.FilterQuality v) {
+  switch (v) {
+    case ui.FilterQuality.none:
+      return i.FilterQuality.none;
+    case ui.FilterQuality.low:
+      return i.FilterQuality.low;
+    case ui.FilterQuality.medium:
+      return i.FilterQuality.medium;
+    case ui.FilterQuality.high:
+      return i.FilterQuality.high;
+  }
+}
+
+ui.BlendMode blendModeToUi(i.BlendMode v) {
+  switch (v) {
+    case i.BlendMode.clear:
+      return ui.BlendMode.clear;
+    case i.BlendMode.src:
+      return ui.BlendMode.src;
+    case i.BlendMode.dst:
+      return ui.BlendMode.dst;
+    case i.BlendMode.srcOver:
+      return ui.BlendMode.srcOver;
+    case i.BlendMode.dstOver:
+      return ui.BlendMode.dstOver;
+    case i.BlendMode.srcIn:
+      return ui.BlendMode.srcIn;
+    case i.BlendMode.dstIn:
+      return ui.BlendMode.dstIn;
+    case i.BlendMode.srcOut:
+      return ui.BlendMode.srcOut;
+    case i.BlendMode.dstOut:
+      return ui.BlendMode.dstOut;
+    case i.BlendMode.srcATop:
+      return ui.BlendMode.srcATop;
+    case i.BlendMode.dstATop:
+      return ui.BlendMode.dstATop;
+    case i.BlendMode.xor:
+      return ui.BlendMode.xor;
+    case i.BlendMode.plus:
+      return ui.BlendMode.plus;
+    case i.BlendMode.modulate:
+      return ui.BlendMode.modulate;
+    case i.BlendMode.screen:
+      return ui.BlendMode.screen;
+    case i.BlendMode.overlay:
+      return ui.BlendMode.overlay;
+    case i.BlendMode.darken:
+      return ui.BlendMode.darken;
+    case i.BlendMode.lighten:
+      return ui.BlendMode.lighten;
+    case i.BlendMode.colorDodge:
+      return ui.BlendMode.colorDodge;
+    case i.BlendMode.colorBurn:
+      return ui.BlendMode.colorBurn;
+    case i.BlendMode.hardLight:
+      return ui.BlendMode.hardLight;
+    case i.BlendMode.softLight:
+      return ui.BlendMode.softLight;
+    case i.BlendMode.difference:
+      return ui.BlendMode.difference;
+    case i.BlendMode.exclusion:
+      return ui.BlendMode.exclusion;
+    case i.BlendMode.multiply:
+      return ui.BlendMode.multiply;
+    case i.BlendMode.hue:
+      return ui.BlendMode.hue;
+    case i.BlendMode.saturation:
+      return ui.BlendMode.saturation;
+    case i.BlendMode.color:
+      return ui.BlendMode.color;
+    case i.BlendMode.luminosity:
+      return ui.BlendMode.luminosity;
+  }
+}
+
+ui.ClipOp clipOpToUi(i.ClipOp v) {
+  switch (v) {
+    case i.ClipOp.difference:
+      return ui.ClipOp.difference;
+    case i.ClipOp.intersect:
+      return ui.ClipOp.intersect;
+  }
+}
+
+ui.PathFillType pathFillTypeToUi(i.PathFillType v) {
+  switch (v) {
+    case i.PathFillType.nonZero:
+      return ui.PathFillType.nonZero;
+    case i.PathFillType.evenOdd:
+      return ui.PathFillType.evenOdd;
+  }
+}
+
+i.PathFillType pathFillTypeFromUi(ui.PathFillType v) {
+  switch (v) {
+    case ui.PathFillType.nonZero:
+      return i.PathFillType.nonZero;
+    case ui.PathFillType.evenOdd:
+      return i.PathFillType.evenOdd;
+  }
+}
+
+ui.PointMode pointModeToUi(i.PointMode v) {
+  switch (v) {
+    case i.PointMode.points:
+      return ui.PointMode.points;
+    case i.PointMode.lines:
+      return ui.PointMode.lines;
+    case i.PointMode.polygon:
+      return ui.PointMode.polygon;
+  }
+}
+
+ui.PixelFormat pixelFormatToUi(i.PixelFormat v) {
+  switch (v) {
+    case i.PixelFormat.rgba8888:
+      return ui.PixelFormat.rgba8888;
+    case i.PixelFormat.bgra8888:
+      return ui.PixelFormat.bgra8888;
+    case i.PixelFormat.rgbaFloat32:
+      return ui.PixelFormat.rgbaFloat32;
+  }
+}
+
+ui.ImageByteFormat imageByteFormatToUi(i.ImageByteFormat v) {
+  switch (v) {
+    case i.ImageByteFormat.rawRgba:
+      return ui.ImageByteFormat.rawRgba;
+    case i.ImageByteFormat.rawStraightRgba:
+      return ui.ImageByteFormat.rawStraightRgba;
+    case i.ImageByteFormat.rawUnmodified:
+      return ui.ImageByteFormat.rawUnmodified;
+    case i.ImageByteFormat.png:
+      return ui.ImageByteFormat.png;
+    case i.ImageByteFormat.rawExtendedRgba128:
+      return ui.ImageByteFormat.rawExtendedRgba128;
+  }
+}

--- a/packages/dart_ui_adapter/pubspec.yaml
+++ b/packages/dart_ui_adapter/pubspec.yaml
@@ -1,0 +1,20 @@
+name: dart_ui_adapter
+description: >-
+  Adapts Flutter's engine-provided dart:ui to the dart_ui_interface UiBackend
+  contract. Provides DartUiBackend. Requires the Flutter SDK; this package is
+  intentionally NOT part of the Dart workspace.
+version: 0.1.0
+publish_to: 'none'
+environment:
+  sdk: ^3.5.0
+  flutter: '>=3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  dart_ui_interface:
+    path: ../dart_ui_interface
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  dart_ui_conformance:
+    path: ../dart_ui_conformance

--- a/packages/dart_ui_adapter/test/conformance_test.dart
+++ b/packages/dart_ui_adapter/test/conformance_test.dart
@@ -1,0 +1,14 @@
+// Runs the shared conformance suite against the dart:ui backend.
+//
+// Requires the Flutter SDK: run with `flutter test` (not `dart test`). The
+// engine binding must be initialised so that Picture.toImage / toByteData work.
+
+import 'package:dart_ui_adapter/dart_ui_adapter.dart';
+import 'package:dart_ui_conformance/dart_ui_conformance.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  UiBackend.instance = const DartUiBackend();
+  runDrawingConformanceTests();
+}

--- a/packages/dart_ui_conformance/lib/dart_ui_conformance.dart
+++ b/packages/dart_ui_conformance/lib/dart_ui_conformance.dart
@@ -1,0 +1,112 @@
+/// Backend-agnostic conformance test suite.
+///
+/// Call [runDrawingConformanceTests] from a `test/` entrypoint inside an
+/// `UiBackend.runWith(...)` scope, so the same assertions run against any
+/// backend (plan §7.1).
+library dart_ui_conformance;
+
+import 'dart:typed_data';
+
+import 'package:dart_ui_interface/dart_ui_interface.dart';
+import 'package:test/test.dart';
+
+/// Runs the drawing-pipeline parity tests against whatever [UiBackend] is
+/// currently selected.
+void runDrawingConformanceTests() {
+  group('drawing conformance', () {
+    test('Paint round-trips its properties', () {
+      final paint = Paint()
+        ..color = const Color(0xFF112233)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 4.0
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.bevel
+        ..isAntiAlias = false;
+      // Compare the 32-bit ARGB value: backends (including dart:ui) store paint
+      // color as float32, so the underlying doubles are not bit-stable.
+      expect(paint.color.value, const Color(0xFF112233).value);
+      expect(paint.style, PaintingStyle.stroke);
+      expect(paint.strokeWidth, 4.0);
+      expect(paint.strokeCap, StrokeCap.round);
+      expect(paint.strokeJoin, StrokeJoin.bevel);
+      expect(paint.isAntiAlias, isFalse);
+    });
+
+    test('Path bounds reflect added geometry', () {
+      final path = Path()..addRect(const Rect.fromLTWH(10, 20, 30, 40));
+      final bounds = path.getBounds();
+      expect(bounds.left, closeTo(10, 0.001));
+      expect(bounds.top, closeTo(20, 0.001));
+      expect(bounds.width, closeTo(30, 0.001));
+      expect(bounds.height, closeTo(40, 0.001));
+    });
+
+    test('Path.contains', () {
+      final path = Path()..addRect(const Rect.fromLTWH(0, 0, 100, 100));
+      expect(path.contains(const Offset(50, 50)), isTrue);
+      expect(path.contains(const Offset(150, 50)), isFalse);
+    });
+
+    test('PictureRecorder lifecycle', () {
+      final recorder = PictureRecorder();
+      expect(recorder.isRecording, isTrue);
+      Canvas(recorder, const Rect.fromLTWH(0, 0, 50, 50))
+          .drawRect(const Rect.fromLTWH(0, 0, 50, 50), Paint());
+      final picture = recorder.endRecording();
+      expect(recorder.isRecording, isFalse);
+      picture.dispose();
+    });
+
+    test('render a rectangle to an image and read pixels back', () async {
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder, const Rect.fromLTWH(0, 0, 20, 20));
+      canvas.drawRect(
+        const Rect.fromLTWH(0, 0, 20, 20),
+        Paint()..color = const Color(0xFFFF0000),
+      );
+      final picture = recorder.endRecording();
+      final image = await picture.toImage(20, 20);
+      expect(image.width, 20);
+      expect(image.height, 20);
+
+      final bytes = await image.toByteData();
+      expect(bytes, isNotNull);
+      final data = bytes!.buffer.asUint8List();
+      // Top-left pixel should be opaque red.
+      expect(data[0], 255, reason: 'red channel');
+      expect(data[1], 0, reason: 'green channel');
+      expect(data[2], 0, reason: 'blue channel');
+      expect(data[3], 255, reason: 'alpha channel');
+
+      image.dispose();
+      picture.dispose();
+    });
+
+    test('save/restore balances the save count', () {
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder, const Rect.fromLTWH(0, 0, 10, 10));
+      final start = canvas.getSaveCount();
+      canvas.save();
+      canvas.translate(5, 5);
+      expect(canvas.getSaveCount(), start + 1);
+      canvas.restore();
+      expect(canvas.getSaveCount(), start);
+      recorder.endRecording().dispose();
+    });
+
+    test('decodeImageFromPixels produces a usable image', () async {
+      final pixels = Uint8List(4 * 4 * 4); // 4x4 RGBA
+      for (var i = 0; i < pixels.length; i += 4) {
+        pixels[i] = 0; // r
+        pixels[i + 1] = 255; // g
+        pixels[i + 2] = 0; // b
+        pixels[i + 3] = 255; // a
+      }
+      final image = await UiBackend.instance
+          .decodeImageFromPixels(pixels, 4, 4, PixelFormat.rgba8888);
+      expect(image.width, 4);
+      expect(image.height, 4);
+      image.dispose();
+    });
+  });
+}

--- a/packages/dart_ui_conformance/pubspec.yaml
+++ b/packages/dart_ui_conformance/pubspec.yaml
@@ -1,0 +1,14 @@
+name: dart_ui_conformance
+description: >-
+  Backend-agnostic conformance / parity test suite for the dart:ui ↔ pure_ui
+  switching architecture. Dev tooling only.
+version: 0.1.0
+publish_to: 'none'
+environment:
+  sdk: ^3.5.0
+resolution: workspace
+dependencies:
+  dart_ui_interface:
+  test: ^1.24.0
+dev_dependencies:
+  pure_ui_adapter:

--- a/packages/dart_ui_conformance/test/pure_ui_backend_test.dart
+++ b/packages/dart_ui_conformance/test/pure_ui_backend_test.dart
@@ -1,0 +1,10 @@
+// Runs the shared conformance suite against the pure_ui backend. This requires
+// no Flutter and is the fast CI path (plan §7.4).
+
+import 'package:dart_ui_conformance/dart_ui_conformance.dart';
+import 'package:pure_ui_adapter/pure_ui_adapter.dart';
+
+void main() {
+  UiBackend.instance = const PureUiBackend();
+  runDrawingConformanceTests();
+}

--- a/packages/dart_ui_interface/lib/dart_ui_interface.dart
+++ b/packages/dart_ui_interface/lib/dart_ui_interface.dart
@@ -1,0 +1,20 @@
+/// Backend-agnostic contract layer for the `dart:ui` / `pure_ui` switching
+/// architecture.
+///
+/// This package defines:
+/// * concrete value types ([Offset], [Size], [Rect], [RRect], [Radius],
+///   [Color]) with their `const` constructors preserved;
+/// * shared enums;
+/// * the [UiBackend] contract plus its global / zone-scoped selection;
+/// * public abstract resource types ([Paint], [Path], [Canvas], [Picture],
+///   [PictureRecorder], [Image]) that dispatch construction to the current
+///   backend.
+///
+/// It has no Flutter dependency.
+library dart_ui_interface;
+
+export 'src/backend.dart';
+export 'src/enums.dart';
+export 'src/functions.dart';
+export 'src/painting.dart';
+export 'src/values.dart';

--- a/packages/dart_ui_interface/lib/src/backend.dart
+++ b/packages/dart_ui_interface/lib/src/backend.dart
@@ -1,0 +1,79 @@
+// The backend contract and its global/zone-scoped selection mechanism.
+//
+// See plan §3.1 and §3.2.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'enums.dart';
+import 'painting.dart';
+import 'values.dart';
+
+/// The factory contract a drawing backend (`pure_ui` or `dart:ui`) must
+/// satisfy. Only *resource-holding* types are dispatched through here; pure
+/// value types ([Offset], [Rect], [Color], ...) are never routed through a
+/// backend.
+abstract interface class UiBackend {
+  static UiBackend? _global;
+
+  /// The current backend. A zone override (installed by [runWith]) takes
+  /// precedence over the global default.
+  static UiBackend get instance {
+    final Object? zoned = Zone.current[#dartUiBackend];
+    if (zoned is UiBackend) {
+      return zoned;
+    }
+    final UiBackend? g = _global;
+    if (g == null) {
+      throw StateError(
+        'No UiBackend registered. Import package:dart_ui_wrapper/ui.dart '
+        '(which wires a default), or set UiBackend.instance = ... explicitly.',
+      );
+    }
+    return g;
+  }
+
+  /// Installs [backend] as the global default (typically once at startup).
+  static set instance(UiBackend backend) => _global = backend;
+
+  /// Whether a global backend has been registered.
+  static bool get hasInstance => _global != null;
+
+  /// Runs [body] with [backend] selected for the dynamic extent of the call.
+  /// Concurrency-safe and nestable (plan §3.2).
+  static T runWith<T>(UiBackend backend, T Function() body) =>
+      runZoned(body, zoneValues: <Object?, Object?>{#dartUiBackend: backend});
+
+  /// A short identifier for diagnostics, e.g. `'pure_ui'` or `'dart:ui'`.
+  String get name;
+
+  /// Whether the backend implements [feature]. See [BackendFeature].
+  bool supports(BackendFeature feature);
+
+  // --- painting ---
+  Paint createPaint();
+  Path createPath();
+  PictureRecorder createPictureRecorder();
+  Canvas createCanvas(PictureRecorder recorder, [Rect? cullRect]);
+
+  // --- image / async ---
+  Future<Image> decodeImageFromPixels(
+    Uint8List pixels,
+    int width,
+    int height,
+    PixelFormat format,
+  );
+
+  /// Creates an [Image] directly from already-decoded RGBA pixel data.
+  Image createImageFromPixels(Uint8List pixels, int width, int height);
+}
+
+/// Capabilities that a backend may or may not implement (plan §5).
+enum BackendFeature {
+  drawing,
+  imageCodec,
+  shaders,
+  imageFilters,
+  text,
+  fragmentShaders,
+}

--- a/packages/dart_ui_interface/lib/src/enums.dart
+++ b/packages/dart_ui_interface/lib/src/enums.dart
@@ -1,0 +1,143 @@
+// Enums shared by every backend.
+//
+// Per the plan (§4.2) these are defined once here. Adapters must map them to
+// the backend's native enums with *explicit* switches — never by relying on
+// `index` matching, which can drift between versions.
+
+/// Algorithms to use when painting on the canvas.
+enum BlendMode {
+  clear,
+  src,
+  dst,
+  srcOver,
+  dstOver,
+  srcIn,
+  dstIn,
+  srcOut,
+  dstOut,
+  srcATop,
+  dstATop,
+  xor,
+  plus,
+  modulate,
+  screen,
+  overlay,
+  darken,
+  lighten,
+  colorDodge,
+  colorBurn,
+  hardLight,
+  softLight,
+  difference,
+  exclusion,
+  multiply,
+  hue,
+  saturation,
+  color,
+  luminosity,
+}
+
+/// Strategies for painting shapes and paths on a canvas.
+enum PaintingStyle {
+  fill,
+  stroke,
+}
+
+/// Styles to use for line endings.
+enum StrokeCap {
+  butt,
+  round,
+  square,
+}
+
+/// Styles to use for line segment joins.
+enum StrokeJoin {
+  miter,
+  round,
+  bevel,
+}
+
+/// Styles to use for blurs in [MaskFilter] objects.
+enum BlurStyle {
+  normal,
+  solid,
+  outer,
+  inner,
+}
+
+/// Quality levels for image sampling in [ImageFilter] and [Shader] objects.
+enum FilterQuality {
+  none,
+  low,
+  medium,
+  high,
+}
+
+/// Different ways to clip a widget's content.
+enum Clip {
+  none,
+  hardEdge,
+  antiAlias,
+  antiAliasWithSaveLayer,
+}
+
+/// How to clip a [Rect] in a canvas.
+enum ClipOp {
+  difference,
+  intersect,
+}
+
+/// Determines the winding rule that decides how the interior of a [Path] is
+/// calculated.
+enum PathFillType {
+  nonZero,
+  evenOdd,
+}
+
+/// Strategies for combining paths.
+enum PathOperation {
+  difference,
+  intersect,
+  union,
+  xor,
+  reverseDifference,
+}
+
+/// Defines how a list of points is interpreted when drawing a set of triangles.
+enum VertexMode {
+  triangles,
+  triangleStrip,
+  triangleFan,
+}
+
+/// Defines how a list of points is interpreted when drawing a set of points.
+enum PointMode {
+  points,
+  lines,
+  polygon,
+}
+
+/// Defines what happens at the edge of a gradient or the sampling of a source
+/// image in an [ImageFilter].
+enum TileMode {
+  clamp,
+  repeated,
+  mirror,
+  decal,
+}
+
+/// The format of pixel data given to [decodeImageFromPixels].
+enum PixelFormat {
+  rgba8888,
+  bgra8888,
+  rgbaFloat32,
+}
+
+/// The format in which image bytes should be returned.
+enum ImageByteFormat {
+  rawRgba,
+  rawStraightRgba,
+  rawUnmodified,
+  png,
+  rawExtendedRgba128,
+}

--- a/packages/dart_ui_interface/lib/src/functions.dart
+++ b/packages/dart_ui_interface/lib/src/functions.dart
@@ -1,0 +1,28 @@
+// Top-level helpers that are pure computation (plan §4.4). These do not depend
+// on a backend.
+
+/// Linearly interpolate between [a] and [b] by [t]. Returns null if both are
+/// null, matching `dart:ui`.
+double? lerpDouble(num? a, num? b, double t) {
+  if (a == b || (a?.isNaN ?? false) && (b?.isNaN ?? false)) {
+    return a?.toDouble();
+  }
+  a ??= 0.0;
+  b ??= 0.0;
+  return a.toDouble() * (1.0 - t) + b.toDouble() * t;
+}
+
+/// Same as [num.clamp] but specialized for non-null [double]s; avoids the
+/// boxing overhead and matches `dart:ui.clampDouble`.
+double clampDouble(double x, double min, double max) {
+  if (x < min) {
+    return min;
+  }
+  if (x > max) {
+    return max;
+  }
+  if (x.isNaN) {
+    return max;
+  }
+  return x;
+}

--- a/packages/dart_ui_interface/lib/src/painting.dart
+++ b/packages/dart_ui_interface/lib/src/painting.dart
@@ -1,0 +1,158 @@
+// Public abstract resource types with factory dispatch (plan §3.3).
+//
+// `Paint()`, `Canvas(recorder)`, etc. route to `UiBackend.instance`. Each
+// backend returns its own concrete type that `implements` these contracts.
+
+import 'dart:typed_data';
+
+import 'backend.dart';
+import 'enums.dart';
+import 'values.dart';
+
+/// A description of the style to use when drawing on a [Canvas].
+abstract class Paint {
+  factory Paint() => UiBackend.instance.createPaint();
+
+  BlendMode get blendMode;
+  set blendMode(BlendMode value);
+
+  Color get color;
+  set color(Color value);
+
+  FilterQuality get filterQuality;
+  set filterQuality(FilterQuality value);
+
+  bool get invertColors;
+  set invertColors(bool value);
+
+  bool get isAntiAlias;
+  set isAntiAlias(bool value);
+
+  StrokeCap get strokeCap;
+  set strokeCap(StrokeCap value);
+
+  StrokeJoin get strokeJoin;
+  set strokeJoin(StrokeJoin value);
+
+  double get strokeMiterLimit;
+  set strokeMiterLimit(double value);
+
+  double get strokeWidth;
+  set strokeWidth(double value);
+
+  PaintingStyle get style;
+  set style(PaintingStyle value);
+}
+
+/// A complex, one-dimensional subset of a plane.
+abstract class Path {
+  factory Path() => UiBackend.instance.createPath();
+
+  PathFillType get fillType;
+  set fillType(PathFillType value);
+
+  void moveTo(double x, double y);
+  void lineTo(double x, double y);
+  void relativeMoveTo(double dx, double dy);
+  void relativeLineTo(double dx, double dy);
+  void quadraticBezierTo(double x1, double y1, double x2, double y2);
+  void relativeQuadraticBezierTo(double x1, double y1, double x2, double y2);
+  void cubicTo(
+      double x1, double y1, double x2, double y2, double x3, double y3);
+  void relativeCubicTo(
+      double x1, double y1, double x2, double y2, double x3, double y3);
+  void conicTo(double x1, double y1, double x2, double y2, double w);
+  void relativeConicTo(double x1, double y1, double x2, double y2, double w);
+  void arcTo(Rect rect, double startAngle, double sweepAngle, bool forceMoveTo);
+  void arcToPoint(
+    Offset arcEnd, {
+    Radius radius,
+    double rotation,
+    bool largeArc,
+    bool clockwise,
+  });
+  void addArc(Rect oval, double startAngle, double sweepAngle);
+  void addOval(Rect oval);
+  void addRect(Rect rect);
+  void addRRect(RRect rrect);
+  void addPolygon(List<Offset> points, bool close);
+  void addPath(Path path, Offset offset, {Float64List? matrix4});
+  void extendWithPath(Path path, Offset offset, {Float64List? matrix4});
+  void close();
+  void reset();
+  bool contains(Offset point);
+  Rect getBounds();
+  Path shift(Offset offset);
+  Path transform(Float64List matrix4);
+}
+
+/// An interface for recording graphical operations.
+abstract class Canvas {
+  factory Canvas(PictureRecorder recorder, [Rect? cullRect]) =>
+      UiBackend.instance.createCanvas(recorder, cullRect);
+
+  void save();
+  void saveLayer(Rect? bounds, Paint paint);
+  void restore();
+  void restoreToCount(int count);
+  int getSaveCount();
+  void translate(double dx, double dy);
+  void scale(double sx, [double? sy]);
+  void rotate(double radians);
+  void skew(double sx, double sy);
+  void transform(Float64List matrix4);
+  Float64List getTransform();
+
+  void clipRect(Rect rect,
+      {ClipOp clipOp = ClipOp.intersect, bool doAntiAlias = true});
+  void clipRRect(RRect rrect, {bool doAntiAlias = true});
+  void clipPath(Path path, {bool doAntiAlias = true});
+  Rect getLocalClipBounds();
+  Rect getDestinationClipBounds();
+
+  void drawColor(Color color, BlendMode blendMode);
+  void drawPaint(Paint paint);
+  void drawLine(Offset p1, Offset p2, Paint paint);
+  void drawRect(Rect rect, Paint paint);
+  void drawRRect(RRect rrect, Paint paint);
+  void drawDRRect(RRect outer, RRect inner, Paint paint);
+  void drawOval(Rect rect, Paint paint);
+  void drawCircle(Offset c, double radius, Paint paint);
+  void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter,
+      Paint paint);
+  void drawPath(Path path, Paint paint);
+  void drawImage(Image image, Offset offset, Paint paint);
+  void drawImageRect(Image image, Rect src, Rect dst, Paint paint);
+  void drawPoints(PointMode pointMode, List<Offset> points, Paint paint);
+  void drawPicture(Picture picture);
+}
+
+/// An object representing a sequence of recorded graphical operations.
+abstract class Picture {
+  int get approximateBytesUsed;
+  bool get debugDisposed;
+  Future<Image> toImage(int width, int height);
+  Image toImageSync(int width, int height);
+  void dispose();
+}
+
+/// A class that enables the creation of a [Picture] from a series of canvas
+/// drawing commands.
+abstract class PictureRecorder {
+  factory PictureRecorder() => UiBackend.instance.createPictureRecorder();
+
+  bool get isRecording;
+  Picture endRecording();
+}
+
+/// An immutable, rasterized image.
+abstract class Image {
+  int get width;
+  int get height;
+  bool get debugDisposed;
+  Image clone();
+  bool isCloneOf(Image other);
+  Future<ByteData?> toByteData(
+      {ImageByteFormat format = ImageByteFormat.rawRgba});
+  void dispose();
+}

--- a/packages/dart_ui_interface/lib/src/values.dart
+++ b/packages/dart_ui_interface/lib/src/values.dart
@@ -1,0 +1,660 @@
+// Concrete value types shared by every backend.
+//
+// Per the switching-architecture plan (§1.3), these are pure data types with
+// no engine resources. They are implemented *once* here, with their `const`
+// constructors preserved, and re-exported by every backend. They are never
+// routed through `UiBackend` factory dispatch.
+
+import 'dart:math' as math;
+
+/// Base class for [Offset] and [Size], holding two doubles.
+abstract class OffsetBase {
+  const OffsetBase(this._dx, this._dy);
+
+  final double _dx;
+  final double _dy;
+
+  /// Whether either component is [double.infinity] or [double.nan].
+  bool get isInfinite => _dx >= double.infinity || _dy >= double.infinity;
+
+  /// Whether both components are finite.
+  bool get isFinite => _dx.isFinite && _dy.isFinite;
+
+  bool operator <(OffsetBase other) => _dx < other._dx && _dy < other._dy;
+  bool operator <=(OffsetBase other) => _dx <= other._dx && _dy <= other._dy;
+  bool operator >(OffsetBase other) => _dx > other._dx && _dy > other._dy;
+  bool operator >=(OffsetBase other) => _dx >= other._dx && _dy >= other._dy;
+
+  @override
+  bool operator ==(Object other) =>
+      other is OffsetBase && other._dx == _dx && other._dy == _dy;
+
+  @override
+  int get hashCode => Object.hash(_dx, _dy);
+
+  @override
+  String toString() => 'OffsetBase(${_dx.toStringAsFixed(1)}, '
+      '${_dy.toStringAsFixed(1)})';
+}
+
+/// An immutable 2D floating-point offset.
+class Offset extends OffsetBase {
+  const Offset(super.dx, super.dy);
+
+  /// Creates an offset from its [direction] (radians) and [distance].
+  factory Offset.fromDirection(double direction, [double distance = 1.0]) {
+    return Offset(
+        distance * math.cos(direction), distance * math.sin(direction));
+  }
+
+  /// An offset with zero magnitude.
+  static const Offset zero = Offset(0.0, 0.0);
+
+  /// An offset with infinite x and y components.
+  static const Offset infinite = Offset(double.infinity, double.infinity);
+
+  double get dx => _dx;
+  double get dy => _dy;
+
+  /// The magnitude of the offset.
+  double get distance => math.sqrt(_dx * _dx + _dy * _dy);
+
+  /// The square of the magnitude of the offset.
+  double get distanceSquared => _dx * _dx + _dy * _dy;
+
+  /// The angle of this offset in radians.
+  double get direction => math.atan2(_dy, _dx);
+
+  Offset scale(double scaleX, double scaleY) =>
+      Offset(_dx * scaleX, _dy * scaleY);
+
+  Offset translate(double translateX, double translateY) =>
+      Offset(_dx + translateX, _dy + translateY);
+
+  Offset operator -() => Offset(-_dx, -_dy);
+  Offset operator -(Offset other) => Offset(_dx - other._dx, _dy - other._dy);
+  Offset operator +(Offset other) => Offset(_dx + other._dx, _dy + other._dy);
+  Offset operator *(double operand) => Offset(_dx * operand, _dy * operand);
+  Offset operator /(double operand) => Offset(_dx / operand, _dy / operand);
+  Offset operator %(double operand) => Offset(_dx % operand, _dy % operand);
+
+  Rect operator &(Size other) =>
+      Rect.fromLTWH(_dx, _dy, other.width, other.height);
+
+  static Offset? lerp(Offset? a, Offset? b, double t) {
+    if (b == null) {
+      if (a == null) {
+        return null;
+      }
+      return a * (1.0 - t);
+    }
+    if (a == null) {
+      return b * t;
+    }
+    return Offset(_lerpD(a._dx, b._dx, t), _lerpD(a._dy, b._dy, t));
+  }
+
+  @override
+  String toString() =>
+      'Offset(${_dx.toStringAsFixed(1)}, ${_dy.toStringAsFixed(1)})';
+}
+
+/// Holds a 2D floating-point size.
+class Size extends OffsetBase {
+  const Size(super.width, super.height);
+  Size.copy(Size source) : super(source.width, source.height);
+  const Size.square(double dimension) : super(dimension, dimension);
+  const Size.fromWidth(double width) : super(width, double.infinity);
+  const Size.fromHeight(double height) : super(double.infinity, height);
+  const Size.fromRadius(double radius) : super(radius * 2.0, radius * 2.0);
+
+  static const Size zero = Size(0.0, 0.0);
+  static const Size infinite = Size(double.infinity, double.infinity);
+
+  double get width => _dx;
+  double get height => _dy;
+
+  double get aspectRatio {
+    if (height != 0.0) {
+      return width / height;
+    }
+    if (width > 0.0) {
+      return double.infinity;
+    }
+    if (width < 0.0) {
+      return double.negativeInfinity;
+    }
+    return 0.0;
+  }
+
+  bool get isEmpty => width <= 0.0 || height <= 0.0;
+
+  double get longestSide => math.max(width.abs(), height.abs());
+  double get shortestSide => math.min(width.abs(), height.abs());
+
+  Offset get topLeft => Offset.zero;
+  Offset center(Offset origin) =>
+      Offset(origin.dx + width / 2.0, origin.dy + height / 2.0);
+
+  bool contains(Offset offset) =>
+      offset.dx >= 0.0 &&
+      offset.dx < width &&
+      offset.dy >= 0.0 &&
+      offset.dy < height;
+
+  OffsetBase operator -(OffsetBase other) {
+    if (other is Size) {
+      return Offset(width - other.width, height - other.height);
+    }
+    if (other is Offset) {
+      return Size(width - other.dx, height - other.dy);
+    }
+    throw ArgumentError(other);
+  }
+
+  Size operator +(Offset other) => Size(width + other.dx, height + other.dy);
+  Size operator *(double operand) => Size(width * operand, height * operand);
+  Size operator /(double operand) => Size(width / operand, height / operand);
+
+  static Size? lerp(Size? a, Size? b, double t) {
+    if (b == null) {
+      if (a == null) {
+        return null;
+      }
+      return a * (1.0 - t);
+    }
+    if (a == null) {
+      return b * t;
+    }
+    return Size(_lerpD(a.width, b.width, t), _lerpD(a.height, b.height, t));
+  }
+
+  @override
+  String toString() =>
+      'Size(${width.toStringAsFixed(1)}, ${height.toStringAsFixed(1)})';
+}
+
+/// An immutable, 2D, axis-aligned, floating-point rectangle.
+class Rect {
+  const Rect.fromLTRB(this.left, this.top, this.right, this.bottom);
+
+  const Rect.fromLTWH(double left, double top, double width, double height)
+      : this.fromLTRB(left, top, left + width, top + height);
+
+  Rect.fromCircle({required Offset center, required double radius})
+      : this.fromCenter(
+          center: center,
+          width: radius * 2,
+          height: radius * 2,
+        );
+
+  Rect.fromCenter(
+      {required Offset center, required double width, required double height})
+      : this.fromLTRB(
+          center.dx - width / 2,
+          center.dy - height / 2,
+          center.dx + width / 2,
+          center.dy + height / 2,
+        );
+
+  Rect.fromPoints(Offset a, Offset b)
+      : this.fromLTRB(
+          math.min(a.dx, b.dx),
+          math.min(a.dy, b.dy),
+          math.max(a.dx, b.dx),
+          math.max(a.dy, b.dy),
+        );
+
+  final double left;
+  final double top;
+  final double right;
+  final double bottom;
+
+  static const Rect zero = Rect.fromLTRB(0.0, 0.0, 0.0, 0.0);
+
+  static const double _giantScalar = 1.0E+9;
+  static const Rect largest =
+      Rect.fromLTRB(-_giantScalar, -_giantScalar, _giantScalar, _giantScalar);
+
+  double get width => right - left;
+  double get height => bottom - top;
+  Size get size => Size(width, height);
+
+  bool get hasNaN => left.isNaN || top.isNaN || right.isNaN || bottom.isNaN;
+  bool get isInfinite =>
+      left >= double.infinity ||
+      top >= double.infinity ||
+      right >= double.infinity ||
+      bottom >= double.infinity;
+  bool get isFinite =>
+      left.isFinite && top.isFinite && right.isFinite && bottom.isFinite;
+  bool get isEmpty => left >= right || top >= bottom;
+
+  Offset get topLeft => Offset(left, top);
+  Offset get topCenter => Offset(left + width / 2.0, top);
+  Offset get topRight => Offset(right, top);
+  Offset get centerLeft => Offset(left, top + height / 2.0);
+  Offset get center => Offset(left + width / 2.0, top + height / 2.0);
+  Offset get centerRight => Offset(right, top + height / 2.0);
+  Offset get bottomLeft => Offset(left, bottom);
+  Offset get bottomCenter => Offset(left + width / 2.0, bottom);
+  Offset get bottomRight => Offset(right, bottom);
+  double get shortestSide => math.min(width.abs(), height.abs());
+  double get longestSide => math.max(width.abs(), height.abs());
+
+  Rect shift(Offset offset) => Rect.fromLTRB(
+      left + offset.dx, top + offset.dy, right + offset.dx, bottom + offset.dy);
+
+  Rect translate(double translateX, double translateY) => Rect.fromLTRB(
+      left + translateX,
+      top + translateY,
+      right + translateX,
+      bottom + translateY);
+
+  Rect inflate(double delta) =>
+      Rect.fromLTRB(left - delta, top - delta, right + delta, bottom + delta);
+
+  Rect deflate(double delta) => inflate(-delta);
+
+  Rect intersect(Rect other) => Rect.fromLTRB(
+        math.max(left, other.left),
+        math.max(top, other.top),
+        math.min(right, other.right),
+        math.min(bottom, other.bottom),
+      );
+
+  Rect expandToInclude(Rect other) => Rect.fromLTRB(
+        math.min(left, other.left),
+        math.min(top, other.top),
+        math.max(right, other.right),
+        math.max(bottom, other.bottom),
+      );
+
+  bool overlaps(Rect other) {
+    if (right <= other.left || other.right <= left) {
+      return false;
+    }
+    if (bottom <= other.top || other.bottom <= top) {
+      return false;
+    }
+    return true;
+  }
+
+  bool contains(Offset offset) =>
+      offset.dx >= left &&
+      offset.dx < right &&
+      offset.dy >= top &&
+      offset.dy < bottom;
+
+  static Rect? lerp(Rect? a, Rect? b, double t) {
+    if (b == null) {
+      if (a == null) {
+        return null;
+      }
+      final double k = 1.0 - t;
+      return Rect.fromLTRB(a.left * k, a.top * k, a.right * k, a.bottom * k);
+    }
+    if (a == null) {
+      return Rect.fromLTRB(b.left * t, b.top * t, b.right * t, b.bottom * t);
+    }
+    return Rect.fromLTRB(
+      _lerpD(a.left, b.left, t),
+      _lerpD(a.top, b.top, t),
+      _lerpD(a.right, b.right, t),
+      _lerpD(a.bottom, b.bottom, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is Rect &&
+      other.left == left &&
+      other.top == top &&
+      other.right == right &&
+      other.bottom == bottom;
+
+  @override
+  int get hashCode => Object.hash(left, top, right, bottom);
+
+  @override
+  String toString() => 'Rect.fromLTRB(${left.toStringAsFixed(1)}, '
+      '${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, '
+      '${bottom.toStringAsFixed(1)})';
+}
+
+/// A radius for either circular or elliptical (oval) shapes.
+class Radius {
+  const Radius.circular(double radius) : this.elliptical(radius, radius);
+  const Radius.elliptical(this.x, this.y);
+
+  final double x;
+  final double y;
+
+  static const Radius zero = Radius.circular(0.0);
+
+  Radius operator -() => Radius.elliptical(-x, -y);
+  Radius operator -(Radius other) =>
+      Radius.elliptical(x - other.x, y - other.y);
+  Radius operator +(Radius other) =>
+      Radius.elliptical(x + other.x, y + other.y);
+  Radius operator *(double operand) =>
+      Radius.elliptical(x * operand, y * operand);
+  Radius operator /(double operand) =>
+      Radius.elliptical(x / operand, y / operand);
+
+  static Radius? lerp(Radius? a, Radius? b, double t) {
+    if (b == null) {
+      if (a == null) {
+        return null;
+      }
+      final double k = 1.0 - t;
+      return Radius.elliptical(a.x * k, a.y * k);
+    }
+    if (a == null) {
+      return Radius.elliptical(b.x * t, b.y * t);
+    }
+    return Radius.elliptical(_lerpD(a.x, b.x, t), _lerpD(a.y, b.y, t));
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is Radius && other.x == x && other.y == y;
+
+  @override
+  int get hashCode => Object.hash(x, y);
+
+  @override
+  String toString() => x == y
+      ? 'Radius.circular(${x.toStringAsFixed(1)})'
+      : 'Radius.elliptical(${x.toStringAsFixed(1)}, ${y.toStringAsFixed(1)})';
+}
+
+/// An immutable rounded rectangle with possibly non-uniform corner radii.
+class RRect {
+  const RRect.fromLTRBXY(
+    this.left,
+    this.top,
+    this.right,
+    this.bottom,
+    double radiusX,
+    double radiusY,
+  )   : tlRadiusX = radiusX,
+        tlRadiusY = radiusY,
+        trRadiusX = radiusX,
+        trRadiusY = radiusY,
+        brRadiusX = radiusX,
+        brRadiusY = radiusY,
+        blRadiusX = radiusX,
+        blRadiusY = radiusY;
+
+  RRect.fromLTRBR(
+      double left, double top, double right, double bottom, Radius radius)
+      : this.fromLTRBXY(left, top, right, bottom, radius.x, radius.y);
+
+  RRect.fromRectXY(Rect rect, double radiusX, double radiusY)
+      : this.fromLTRBXY(
+            rect.left, rect.top, rect.right, rect.bottom, radiusX, radiusY);
+
+  RRect.fromRectAndRadius(Rect rect, Radius radius)
+      : this.fromLTRBXY(
+            rect.left, rect.top, rect.right, rect.bottom, radius.x, radius.y);
+
+  const RRect._raw({
+    this.left = 0.0,
+    this.top = 0.0,
+    this.right = 0.0,
+    this.bottom = 0.0,
+    this.tlRadiusX = 0.0,
+    this.tlRadiusY = 0.0,
+    this.trRadiusX = 0.0,
+    this.trRadiusY = 0.0,
+    this.brRadiusX = 0.0,
+    this.brRadiusY = 0.0,
+    this.blRadiusX = 0.0,
+    this.blRadiusY = 0.0,
+  });
+
+  RRect.fromLTRBAndCorners(
+    double left,
+    double top,
+    double right,
+    double bottom, {
+    Radius topLeft = Radius.zero,
+    Radius topRight = Radius.zero,
+    Radius bottomRight = Radius.zero,
+    Radius bottomLeft = Radius.zero,
+  }) : this._raw(
+          left: left,
+          top: top,
+          right: right,
+          bottom: bottom,
+          tlRadiusX: topLeft.x,
+          tlRadiusY: topLeft.y,
+          trRadiusX: topRight.x,
+          trRadiusY: topRight.y,
+          brRadiusX: bottomRight.x,
+          brRadiusY: bottomRight.y,
+          blRadiusX: bottomLeft.x,
+          blRadiusY: bottomLeft.y,
+        );
+
+  RRect.fromRectAndCorners(
+    Rect rect, {
+    Radius topLeft = Radius.zero,
+    Radius topRight = Radius.zero,
+    Radius bottomRight = Radius.zero,
+    Radius bottomLeft = Radius.zero,
+  }) : this.fromLTRBAndCorners(
+          rect.left,
+          rect.top,
+          rect.right,
+          rect.bottom,
+          topLeft: topLeft,
+          topRight: topRight,
+          bottomRight: bottomRight,
+          bottomLeft: bottomLeft,
+        );
+
+  final double left;
+  final double top;
+  final double right;
+  final double bottom;
+  final double tlRadiusX;
+  final double tlRadiusY;
+  final double trRadiusX;
+  final double trRadiusY;
+  final double brRadiusX;
+  final double brRadiusY;
+  final double blRadiusX;
+  final double blRadiusY;
+
+  static const RRect zero = RRect._raw();
+
+  Radius get tlRadius => Radius.elliptical(tlRadiusX, tlRadiusY);
+  Radius get trRadius => Radius.elliptical(trRadiusX, trRadiusY);
+  Radius get brRadius => Radius.elliptical(brRadiusX, brRadiusY);
+  Radius get blRadius => Radius.elliptical(blRadiusX, blRadiusY);
+
+  double get width => right - left;
+  double get height => bottom - top;
+  Rect get outerRect => Rect.fromLTRB(left, top, right, bottom);
+  Offset get center => Offset(left + width / 2.0, top + height / 2.0);
+
+  RRect shift(Offset offset) => RRect.fromLTRBAndCorners(
+        left + offset.dx,
+        top + offset.dy,
+        right + offset.dx,
+        bottom + offset.dy,
+        topLeft: tlRadius,
+        topRight: trRadius,
+        bottomRight: brRadius,
+        bottomLeft: blRadius,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is RRect &&
+      other.left == left &&
+      other.top == top &&
+      other.right == right &&
+      other.bottom == bottom &&
+      other.tlRadiusX == tlRadiusX &&
+      other.tlRadiusY == tlRadiusY &&
+      other.trRadiusX == trRadiusX &&
+      other.trRadiusY == trRadiusY &&
+      other.brRadiusX == brRadiusX &&
+      other.brRadiusY == brRadiusY &&
+      other.blRadiusX == blRadiusX &&
+      other.blRadiusY == blRadiusY;
+
+  @override
+  int get hashCode => Object.hash(
+      left,
+      top,
+      right,
+      bottom,
+      tlRadiusX,
+      tlRadiusY,
+      trRadiusX,
+      trRadiusY,
+      brRadiusX,
+      brRadiusY,
+      blRadiusX,
+      blRadiusY);
+
+  @override
+  String toString() => 'RRect.fromLTRBR(${left.toStringAsFixed(1)}, '
+      '${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, '
+      '${bottom.toStringAsFixed(1)}, $tlRadius)';
+}
+
+/// An immutable 32 bit color value in ARGB format, with wide-gamut support.
+class Color {
+  const Color(int value)
+      : this._fromARGBC(
+          (0xff000000 & value) >> 24,
+          (0x00ff0000 & value) >> 16,
+          (0x0000ff00 & value) >> 8,
+          (0x000000ff & value) >> 0,
+        );
+
+  const Color._fromARGBC(int a, int r, int g, int b)
+      : a = a / 255.0,
+        r = r / 255.0,
+        g = g / 255.0,
+        b = b / 255.0;
+
+  const Color.fromARGB(int a, int r, int g, int b)
+      : this._fromARGBC(a, r, g, b);
+
+  const Color.fromRGBO(int r, int g, int b, double opacity)
+      : a = opacity,
+        r = r / 255.0,
+        g = g / 255.0,
+        b = b / 255.0;
+
+  const Color.from({
+    required double alpha,
+    required double red,
+    required double green,
+    required double blue,
+  })  : a = alpha,
+        r = red,
+        g = green,
+        b = blue;
+
+  /// The alpha channel as a double between 0.0 and 1.0.
+  final double a;
+
+  /// The red channel as a double between 0.0 and 1.0.
+  final double r;
+
+  /// The green channel as a double between 0.0 and 1.0.
+  final double g;
+
+  /// The blue channel as a double between 0.0 and 1.0.
+  final double b;
+
+  int get alpha => (a * 255.0).round() & 0xff;
+  int get red => (r * 255.0).round() & 0xff;
+  int get green => (g * 255.0).round() & 0xff;
+  int get blue => (b * 255.0).round() & 0xff;
+  double get opacity => alpha / 0xFF;
+
+  /// The 32-bit ARGB representation of this color.
+  int get value => toARGB32();
+
+  int toARGB32() =>
+      ((alpha & 0xff) << 24) |
+      ((red & 0xff) << 16) |
+      ((green & 0xff) << 8) |
+      ((blue & 0xff) << 0);
+
+  Color withAlpha(int a) => Color.fromARGB(a, red, green, blue);
+
+  Color withRed(int r) => Color.fromARGB(alpha, r, green, blue);
+  Color withGreen(int g) => Color.fromARGB(alpha, red, g, blue);
+  Color withBlue(int b) => Color.fromARGB(alpha, red, green, b);
+
+  @Deprecated('Use .withValues() to avoid precision loss.')
+  Color withOpacity(double opacity) => withAlpha((255.0 * opacity).round());
+
+  Color withValues({double? alpha, double? red, double? green, double? blue}) {
+    return Color.from(
+      alpha: alpha ?? a,
+      red: red ?? r,
+      green: green ?? g,
+      blue: blue ?? b,
+    );
+  }
+
+  double computeLuminance() {
+    double linearize(double component) {
+      if (component <= 0.03928) {
+        return component / 12.92;
+      }
+      return math.pow((component + 0.055) / 1.055, 2.4).toDouble();
+    }
+
+    return 0.2126 * linearize(r) +
+        0.7152 * linearize(g) +
+        0.0722 * linearize(b);
+  }
+
+  static Color? lerp(Color? a, Color? b, double t) {
+    if (b == null) {
+      if (a == null) {
+        return null;
+      }
+      return a.withValues(alpha: a.a * (1.0 - t));
+    }
+    if (a == null) {
+      return b.withValues(alpha: b.a * t);
+    }
+    return Color.from(
+      alpha: _clamp01(_lerpD(a.a, b.a, t)),
+      red: _clamp01(_lerpD(a.r, b.r, t)),
+      green: _clamp01(_lerpD(a.g, b.g, t)),
+      blue: _clamp01(_lerpD(a.b, b.b, t)),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is Color &&
+      other.a == a &&
+      other.r == r &&
+      other.g == g &&
+      other.b == b;
+
+  @override
+  int get hashCode => Object.hash(a, r, g, b);
+
+  @override
+  String toString() =>
+      'Color(0x${toARGB32().toRadixString(16).padLeft(8, '0')})';
+}
+
+double _lerpD(double a, double b, double t) => a + (b - a) * t;
+
+double _clamp01(double v) => v < 0.0 ? 0.0 : (v > 1.0 ? 1.0 : v);

--- a/packages/dart_ui_interface/pubspec.yaml
+++ b/packages/dart_ui_interface/pubspec.yaml
@@ -1,0 +1,11 @@
+name: dart_ui_interface
+description: >-
+  Backend-agnostic contract layer (value types, enums, UiBackend, abstract
+  resource types) for the dart:ui / pure_ui switching architecture.
+version: 0.1.0
+publish_to: 'none'
+environment:
+  sdk: ^3.5.0
+resolution: workspace
+dev_dependencies:
+  test: ^1.24.0

--- a/packages/dart_ui_interface/test/values_test.dart
+++ b/packages/dart_ui_interface/test/values_test.dart
@@ -1,0 +1,59 @@
+import 'package:dart_ui_interface/dart_ui_interface.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('value types preserve const', () {
+    test('Offset.zero is a compile-time constant and identical', () {
+      const a = Offset.zero;
+      const b = Offset(0, 0);
+      expect(identical(a, b), isTrue);
+    });
+
+    test('Color const construction', () {
+      const c = Color(0xFF112233);
+      expect(c.alpha, 0xFF);
+      expect(c.red, 0x11);
+      expect(c.green, 0x22);
+      expect(c.blue, 0x33);
+      expect(c.value, 0xFF112233);
+    });
+
+    test('Rect geometry', () {
+      const r = Rect.fromLTWH(10, 20, 30, 40);
+      expect(r.width, 30);
+      expect(r.height, 40);
+      expect(r.center, const Offset(25, 40));
+    });
+
+    test('RRect zero is const', () {
+      const rr = RRect.zero;
+      expect(rr.width, 0);
+      expect(rr.tlRadiusX, 0);
+    });
+
+    test('Offset arithmetic and equality', () {
+      expect(const Offset(1, 2) + const Offset(3, 4), const Offset(4, 6));
+      expect(const Offset(2, 4) / 2, const Offset(1, 2));
+      expect(const Offset(1, 1), equals(const Offset(1, 1)));
+    });
+
+    test('Color.lerp clamps and interpolates', () {
+      final c =
+          Color.lerp(const Color(0xFF000000), const Color(0xFFFFFFFF), 0.5);
+      expect(c!.red, closeTo(128, 1));
+    });
+  });
+
+  group('top-level functions', () {
+    test('lerpDouble', () {
+      expect(lerpDouble(0, 10, 0.5), 5.0);
+      expect(lerpDouble(null, null, 0.5), isNull);
+    });
+
+    test('clampDouble', () {
+      expect(clampDouble(5, 0, 10), 5);
+      expect(clampDouble(-1, 0, 10), 0);
+      expect(clampDouble(11, 0, 10), 10);
+    });
+  });
+}

--- a/packages/dart_ui_wrapper/lib/dart_ui_wrapper.dart
+++ b/packages/dart_ui_wrapper/lib/dart_ui_wrapper.dart
@@ -1,0 +1,31 @@
+/// Backend lifecycle / switching API for the `dart:ui` ↔ `pure_ui` wrapper.
+///
+/// This library is Flutter-free: its only default backend is [PureUiBackend].
+/// Flutter apps that want the `dart:ui` backend depend on `dart_ui_adapter`
+/// separately and call `UiBackend.instance = DartUiBackend()` — keeping the
+/// Flutter dependency out of this package (plan §1.2).
+library dart_ui_wrapper;
+
+import 'package:pure_ui_adapter/pure_ui_adapter.dart';
+
+export 'package:dart_ui_interface/dart_ui_interface.dart';
+export 'package:pure_ui_adapter/pure_ui_adapter.dart' show PureUiBackend;
+
+/// Installs the pure-Dart [PureUiBackend] as the global default backend.
+///
+/// Idempotent: a no-op if a backend is already registered, unless [force] is
+/// set. Call once near application startup in non-Flutter environments.
+void installPureUiBackend({bool force = false}) {
+  if (force || !UiBackend.hasInstance) {
+    UiBackend.instance = const PureUiBackend();
+  }
+}
+
+/// Installs an explicit [backend] as the global default.
+void installBackend(UiBackend backend) {
+  UiBackend.instance = backend;
+}
+
+/// Runs [body] with the pure-Dart backend selected for its dynamic extent.
+T runWithPureUi<T>(T Function() body) =>
+    UiBackend.runWith(const PureUiBackend(), body);

--- a/packages/dart_ui_wrapper/lib/ui.dart
+++ b/packages/dart_ui_wrapper/lib/ui.dart
@@ -1,0 +1,18 @@
+/// Drop-in `dart:ui` replacement surface.
+///
+/// Import this with the same prefix you used for `dart:ui`:
+///
+/// ```dart
+/// // before
+/// import 'dart:ui' as ui;
+/// // after
+/// import 'package:dart_ui_wrapper/ui.dart' as ui;
+/// ```
+///
+/// All construction (`ui.Paint()`, `ui.Canvas(recorder)`, ...) dispatches to the
+/// currently-selected [UiBackend]. Select one once at startup via
+/// `installPureUiBackend()` (the Flutter-free default) or
+/// `UiBackend.instance = ...`. See `dart_ui_wrapper.dart`.
+library ui;
+
+export 'package:dart_ui_interface/dart_ui_interface.dart';

--- a/packages/dart_ui_wrapper/pubspec.yaml
+++ b/packages/dart_ui_wrapper/pubspec.yaml
@@ -1,0 +1,14 @@
+name: dart_ui_wrapper
+description: >-
+  Drop-in dart:ui replacement surface (ui.dart) plus backend lifecycle /
+  switching API. Flutter-free; defaults to the pure_ui backend.
+version: 0.1.0
+publish_to: 'none'
+environment:
+  sdk: ^3.5.0
+resolution: workspace
+dependencies:
+  dart_ui_interface:
+  pure_ui_adapter:
+dev_dependencies:
+  test: ^1.24.0

--- a/packages/pure_ui_adapter/lib/pure_ui_adapter.dart
+++ b/packages/pure_ui_adapter/lib/pure_ui_adapter.dart
@@ -1,0 +1,17 @@
+/// Adapts the pure-Dart `pure_ui` implementation to the [UiBackend] contract.
+///
+/// Provides [PureUiBackend], the default backend for non-Flutter environments.
+/// No Flutter dependency.
+library pure_ui_adapter;
+
+export 'package:dart_ui_interface/dart_ui_interface.dart';
+
+export 'src/backend.dart'
+    show
+        PureUiBackend,
+        PureUiPaint,
+        PureUiPath,
+        PureUiCanvas,
+        PureUiPicture,
+        PureUiPictureRecorder,
+        PureUiImage;

--- a/packages/pure_ui_adapter/lib/src/backend.dart
+++ b/packages/pure_ui_adapter/lib/src/backend.dart
@@ -1,0 +1,378 @@
+// PureUiBackend: adapts pure_ui's concrete types to the interface contract.
+//
+// Per the plan (§2.1) this uses the "pure_ui_adapter" option rather than making
+// pure_ui implement the interface directly, so pure_ui keeps its standalone
+// drop-in behaviour untouched (§6.0). The only cost is value-type conversion at
+// the boundary.
+
+import 'dart:typed_data';
+
+import 'package:dart_ui_interface/dart_ui_interface.dart' as i;
+import 'package:pure_ui/pure_ui.dart' as p;
+
+import 'conv.dart';
+
+/// A [i.UiBackend] backed by the pure-Dart `pure_ui` implementation. Works in
+/// any Dart environment; no Flutter required.
+class PureUiBackend implements i.UiBackend {
+  const PureUiBackend();
+
+  @override
+  String get name => 'pure_ui';
+
+  @override
+  bool supports(i.BackendFeature feature) {
+    switch (feature) {
+      case i.BackendFeature.drawing:
+      case i.BackendFeature.imageCodec:
+      case i.BackendFeature.text:
+        return true;
+      case i.BackendFeature.shaders:
+      case i.BackendFeature.imageFilters:
+      case i.BackendFeature.fragmentShaders:
+        return false;
+    }
+  }
+
+  @override
+  i.Paint createPaint() => PureUiPaint(p.Paint());
+
+  @override
+  i.Path createPath() => PureUiPath(p.Path());
+
+  @override
+  i.PictureRecorder createPictureRecorder() =>
+      PureUiPictureRecorder(p.PictureRecorder());
+
+  @override
+  i.Canvas createCanvas(i.PictureRecorder recorder, [i.Rect? cullRect]) {
+    final p.PictureRecorder raw = (recorder as PureUiPictureRecorder).raw;
+    final p.Canvas canvas =
+        cullRect == null ? p.Canvas(raw) : p.Canvas(raw, rectToPure(cullRect));
+    return PureUiCanvas(canvas);
+  }
+
+  @override
+  Future<i.Image> decodeImageFromPixels(
+    Uint8List pixels,
+    int width,
+    int height,
+    i.PixelFormat format,
+  ) async {
+    // pure_ui treats incoming pixel data as RGBA.
+    return PureUiImage(p.createPureDartImage(pixels, width, height));
+  }
+
+  @override
+  i.Image createImageFromPixels(Uint8List pixels, int width, int height) =>
+      PureUiImage(p.createPureDartImage(pixels, width, height));
+}
+
+/// Wraps a pure_ui [p.Paint].
+class PureUiPaint implements i.Paint {
+  PureUiPaint(this.raw);
+
+  final p.Paint raw;
+
+  @override
+  i.BlendMode get blendMode =>
+      i.BlendMode.values[raw.blendMode.index]; // read-back rarely used
+  @override
+  set blendMode(i.BlendMode value) => raw.blendMode = blendModeToPure(value);
+
+  @override
+  i.Color get color => colorFromPure(raw.color);
+  @override
+  set color(i.Color value) => raw.color = colorToPure(value);
+
+  @override
+  i.FilterQuality get filterQuality => filterQualityFromPure(raw.filterQuality);
+  @override
+  set filterQuality(i.FilterQuality value) =>
+      raw.filterQuality = filterQualityToPure(value);
+
+  @override
+  bool get invertColors => raw.invertColors;
+  @override
+  set invertColors(bool value) => raw.invertColors = value;
+
+  @override
+  bool get isAntiAlias => raw.isAntiAlias;
+  @override
+  set isAntiAlias(bool value) => raw.isAntiAlias = value;
+
+  @override
+  i.StrokeCap get strokeCap => strokeCapFromPure(raw.strokeCap);
+  @override
+  set strokeCap(i.StrokeCap value) => raw.strokeCap = strokeCapToPure(value);
+
+  @override
+  i.StrokeJoin get strokeJoin => strokeJoinFromPure(raw.strokeJoin);
+  @override
+  set strokeJoin(i.StrokeJoin value) =>
+      raw.strokeJoin = strokeJoinToPure(value);
+
+  @override
+  double get strokeMiterLimit => raw.strokeMiterLimit;
+  @override
+  set strokeMiterLimit(double value) => raw.strokeMiterLimit = value;
+
+  @override
+  double get strokeWidth => raw.strokeWidth;
+  @override
+  set strokeWidth(double value) => raw.strokeWidth = value;
+
+  @override
+  i.PaintingStyle get style => paintingStyleFromPure(raw.style);
+  @override
+  set style(i.PaintingStyle value) => raw.style = paintingStyleToPure(value);
+}
+
+/// Wraps a pure_ui [p.Path].
+class PureUiPath implements i.Path {
+  PureUiPath(this.raw);
+
+  final p.Path raw;
+
+  @override
+  i.PathFillType get fillType => pathFillTypeFromPure(raw.fillType);
+  @override
+  set fillType(i.PathFillType value) =>
+      raw.fillType = pathFillTypeToPure(value);
+
+  @override
+  void moveTo(double x, double y) => raw.moveTo(x, y);
+  @override
+  void lineTo(double x, double y) => raw.lineTo(x, y);
+  @override
+  void relativeMoveTo(double dx, double dy) => raw.relativeMoveTo(dx, dy);
+  @override
+  void relativeLineTo(double dx, double dy) => raw.relativeLineTo(dx, dy);
+  @override
+  void quadraticBezierTo(double x1, double y1, double x2, double y2) =>
+      raw.quadraticBezierTo(x1, y1, x2, y2);
+  @override
+  void relativeQuadraticBezierTo(double x1, double y1, double x2, double y2) =>
+      raw.relativeQuadraticBezierTo(x1, y1, x2, y2);
+  @override
+  void cubicTo(
+          double x1, double y1, double x2, double y2, double x3, double y3) =>
+      raw.cubicTo(x1, y1, x2, y2, x3, y3);
+  @override
+  void relativeCubicTo(
+          double x1, double y1, double x2, double y2, double x3, double y3) =>
+      raw.relativeCubicTo(x1, y1, x2, y2, x3, y3);
+  @override
+  void conicTo(double x1, double y1, double x2, double y2, double w) =>
+      raw.conicTo(x1, y1, x2, y2, w);
+  @override
+  void relativeConicTo(double x1, double y1, double x2, double y2, double w) =>
+      raw.relativeConicTo(x1, y1, x2, y2, w);
+  @override
+  void arcTo(i.Rect rect, double startAngle, double sweepAngle,
+          bool forceMoveTo) =>
+      raw.arcTo(rectToPure(rect), startAngle, sweepAngle, forceMoveTo);
+  @override
+  void arcToPoint(
+    i.Offset arcEnd, {
+    i.Radius radius = i.Radius.zero,
+    double rotation = 0.0,
+    bool largeArc = false,
+    bool clockwise = true,
+  }) =>
+      raw.arcToPoint(
+        offsetToPure(arcEnd),
+        radius: radiusToPure(radius),
+        rotation: rotation,
+        largeArc: largeArc,
+        clockwise: clockwise,
+      );
+  @override
+  void addArc(i.Rect oval, double startAngle, double sweepAngle) =>
+      raw.addArc(rectToPure(oval), startAngle, sweepAngle);
+  @override
+  void addOval(i.Rect oval) => raw.addOval(rectToPure(oval));
+  @override
+  void addRect(i.Rect rect) => raw.addRect(rectToPure(rect));
+  @override
+  void addRRect(i.RRect rrect) => raw.addRRect(rrectToPure(rrect));
+  @override
+  void addPolygon(List<i.Offset> points, bool close) =>
+      raw.addPolygon(points.map(offsetToPure).toList(), close);
+  @override
+  void addPath(i.Path path, i.Offset offset, {Float64List? matrix4}) =>
+      raw.addPath((path as PureUiPath).raw, offsetToPure(offset),
+          matrix4: matrix4);
+  @override
+  void extendWithPath(i.Path path, i.Offset offset, {Float64List? matrix4}) =>
+      raw.extendWithPath((path as PureUiPath).raw, offsetToPure(offset),
+          matrix4: matrix4);
+  @override
+  void close() => raw.close();
+  @override
+  void reset() => raw.reset();
+  @override
+  bool contains(i.Offset point) => raw.contains(offsetToPure(point));
+  @override
+  i.Rect getBounds() => rectFromPure(raw.getBounds());
+  @override
+  i.Path shift(i.Offset offset) => PureUiPath(raw.shift(offsetToPure(offset)));
+  @override
+  i.Path transform(Float64List matrix4) => PureUiPath(raw.transform(matrix4));
+}
+
+/// Wraps a pure_ui [p.Canvas].
+class PureUiCanvas implements i.Canvas {
+  PureUiCanvas(this.raw);
+
+  final p.Canvas raw;
+
+  p.Paint _paint(i.Paint paint) => (paint as PureUiPaint).raw;
+
+  @override
+  void save() => raw.save();
+  @override
+  void saveLayer(i.Rect? bounds, i.Paint paint) =>
+      raw.saveLayer(bounds == null ? null : rectToPure(bounds), _paint(paint));
+  @override
+  void restore() => raw.restore();
+  @override
+  void restoreToCount(int count) => raw.restoreToCount(count);
+  @override
+  int getSaveCount() => raw.getSaveCount();
+  @override
+  void translate(double dx, double dy) => raw.translate(dx, dy);
+  @override
+  void scale(double sx, [double? sy]) => raw.scale(sx, sy);
+  @override
+  void rotate(double radians) => raw.rotate(radians);
+  @override
+  void skew(double sx, double sy) => raw.skew(sx, sy);
+  @override
+  void transform(Float64List matrix4) => raw.transform(matrix4);
+  @override
+  Float64List getTransform() => raw.getTransform();
+
+  @override
+  void clipRect(i.Rect rect,
+          {i.ClipOp clipOp = i.ClipOp.intersect, bool doAntiAlias = true}) =>
+      raw.clipRect(rectToPure(rect),
+          clipOp: clipOpToPure(clipOp), doAntiAlias: doAntiAlias);
+  @override
+  void clipRRect(i.RRect rrect, {bool doAntiAlias = true}) =>
+      raw.clipRRect(rrectToPure(rrect), doAntiAlias: doAntiAlias);
+  @override
+  void clipPath(i.Path path, {bool doAntiAlias = true}) =>
+      raw.clipPath((path as PureUiPath).raw, doAntiAlias: doAntiAlias);
+  @override
+  i.Rect getLocalClipBounds() => rectFromPure(raw.getLocalClipBounds());
+  @override
+  i.Rect getDestinationClipBounds() =>
+      rectFromPure(raw.getDestinationClipBounds());
+
+  @override
+  void drawColor(i.Color color, i.BlendMode blendMode) =>
+      raw.drawColor(colorToPure(color), blendModeToPure(blendMode));
+  @override
+  void drawPaint(i.Paint paint) => raw.drawPaint(_paint(paint));
+  @override
+  void drawLine(i.Offset p1, i.Offset p2, i.Paint paint) =>
+      raw.drawLine(offsetToPure(p1), offsetToPure(p2), _paint(paint));
+  @override
+  void drawRect(i.Rect rect, i.Paint paint) =>
+      raw.drawRect(rectToPure(rect), _paint(paint));
+  @override
+  void drawRRect(i.RRect rrect, i.Paint paint) =>
+      raw.drawRRect(rrectToPure(rrect), _paint(paint));
+  @override
+  void drawDRRect(i.RRect outer, i.RRect inner, i.Paint paint) =>
+      raw.drawDRRect(rrectToPure(outer), rrectToPure(inner), _paint(paint));
+  @override
+  void drawOval(i.Rect rect, i.Paint paint) =>
+      raw.drawOval(rectToPure(rect), _paint(paint));
+  @override
+  void drawCircle(i.Offset c, double radius, i.Paint paint) =>
+      raw.drawCircle(offsetToPure(c), radius, _paint(paint));
+  @override
+  void drawArc(i.Rect rect, double startAngle, double sweepAngle,
+          bool useCenter, i.Paint paint) =>
+      raw.drawArc(
+          rectToPure(rect), startAngle, sweepAngle, useCenter, _paint(paint));
+  @override
+  void drawPath(i.Path path, i.Paint paint) =>
+      raw.drawPath((path as PureUiPath).raw, _paint(paint));
+  @override
+  void drawImage(i.Image image, i.Offset offset, i.Paint paint) =>
+      raw.drawImage(
+          (image as PureUiImage).raw, offsetToPure(offset), _paint(paint));
+  @override
+  void drawImageRect(i.Image image, i.Rect src, i.Rect dst, i.Paint paint) =>
+      raw.drawImageRect((image as PureUiImage).raw, rectToPure(src),
+          rectToPure(dst), _paint(paint));
+  @override
+  void drawPoints(
+          i.PointMode pointMode, List<i.Offset> points, i.Paint paint) =>
+      raw.drawPoints(pointModeToPure(pointMode),
+          points.map(offsetToPure).toList(), _paint(paint));
+  @override
+  void drawPicture(i.Picture picture) =>
+      raw.drawPicture((picture as PureUiPicture).raw);
+}
+
+/// Wraps a pure_ui [p.PictureRecorder].
+class PureUiPictureRecorder implements i.PictureRecorder {
+  PureUiPictureRecorder(this.raw);
+
+  final p.PictureRecorder raw;
+
+  @override
+  bool get isRecording => raw.isRecording;
+
+  @override
+  i.Picture endRecording() => PureUiPicture(raw.endRecording());
+}
+
+/// Wraps a pure_ui [p.Picture].
+class PureUiPicture implements i.Picture {
+  PureUiPicture(this.raw);
+
+  final p.Picture raw;
+
+  @override
+  int get approximateBytesUsed => raw.approximateBytesUsed;
+  @override
+  bool get debugDisposed => raw.debugDisposed;
+  @override
+  Future<i.Image> toImage(int width, int height) async =>
+      PureUiImage(await raw.toImage(width, height));
+  @override
+  i.Image toImageSync(int width, int height) =>
+      PureUiImage(raw.toImageSync(width, height));
+  @override
+  void dispose() => raw.dispose();
+}
+
+/// Wraps a pure_ui [p.Image].
+class PureUiImage implements i.Image {
+  PureUiImage(this.raw);
+
+  final p.Image raw;
+
+  @override
+  int get width => raw.width;
+  @override
+  int get height => raw.height;
+  @override
+  bool get debugDisposed => raw.debugDisposed;
+  @override
+  i.Image clone() => PureUiImage(raw.clone());
+  @override
+  bool isCloneOf(i.Image other) =>
+      other is PureUiImage && raw.isCloneOf(other.raw);
+  @override
+  Future<ByteData?> toByteData(
+          {i.ImageByteFormat format = i.ImageByteFormat.rawRgba}) =>
+      raw.toByteData(format: imageByteFormatToPure(format));
+  @override
+  void dispose() => raw.dispose();
+}

--- a/packages/pure_ui_adapter/lib/src/conv.dart
+++ b/packages/pure_ui_adapter/lib/src/conv.dart
@@ -1,0 +1,245 @@
+// Value-type and enum conversions between the interface layer and pure_ui.
+//
+// pure_ui defines its own structurally-identical value types and enums (it
+// mirrors dart:ui), so the conversions here are mechanical. They are the only
+// boundary cost on the pure_ui path.
+
+import 'package:dart_ui_interface/dart_ui_interface.dart' as i;
+import 'package:pure_ui/pure_ui.dart' as p;
+
+// --- value types ---
+
+p.Offset offsetToPure(i.Offset o) => p.Offset(o.dx, o.dy);
+i.Offset offsetFromPure(p.Offset o) => i.Offset(o.dx, o.dy);
+
+p.Size sizeToPure(i.Size s) => p.Size(s.width, s.height);
+i.Size sizeFromPure(p.Size s) => i.Size(s.width, s.height);
+
+p.Rect rectToPure(i.Rect r) =>
+    p.Rect.fromLTRB(r.left, r.top, r.right, r.bottom);
+i.Rect rectFromPure(p.Rect r) =>
+    i.Rect.fromLTRB(r.left, r.top, r.right, r.bottom);
+
+p.Radius radiusToPure(i.Radius r) => p.Radius.elliptical(r.x, r.y);
+
+p.RRect rrectToPure(i.RRect r) => p.RRect.fromLTRBAndCorners(
+      r.left,
+      r.top,
+      r.right,
+      r.bottom,
+      topLeft: radiusToPure(r.tlRadius),
+      topRight: radiusToPure(r.trRadius),
+      bottomRight: radiusToPure(r.brRadius),
+      bottomLeft: radiusToPure(r.blRadius),
+    );
+
+p.Color colorToPure(i.Color c) =>
+    p.Color.from(alpha: c.a, red: c.r, green: c.g, blue: c.b);
+i.Color colorFromPure(p.Color c) =>
+    i.Color.from(alpha: c.a, red: c.r, green: c.g, blue: c.b);
+
+// --- enums (explicit, never index-based) ---
+
+p.PaintingStyle paintingStyleToPure(i.PaintingStyle v) {
+  switch (v) {
+    case i.PaintingStyle.fill:
+      return p.PaintingStyle.fill;
+    case i.PaintingStyle.stroke:
+      return p.PaintingStyle.stroke;
+  }
+}
+
+i.PaintingStyle paintingStyleFromPure(p.PaintingStyle v) {
+  switch (v) {
+    case p.PaintingStyle.fill:
+      return i.PaintingStyle.fill;
+    case p.PaintingStyle.stroke:
+      return i.PaintingStyle.stroke;
+  }
+}
+
+p.StrokeCap strokeCapToPure(i.StrokeCap v) {
+  switch (v) {
+    case i.StrokeCap.butt:
+      return p.StrokeCap.butt;
+    case i.StrokeCap.round:
+      return p.StrokeCap.round;
+    case i.StrokeCap.square:
+      return p.StrokeCap.square;
+  }
+}
+
+i.StrokeCap strokeCapFromPure(p.StrokeCap v) {
+  switch (v) {
+    case p.StrokeCap.butt:
+      return i.StrokeCap.butt;
+    case p.StrokeCap.round:
+      return i.StrokeCap.round;
+    case p.StrokeCap.square:
+      return i.StrokeCap.square;
+  }
+}
+
+p.StrokeJoin strokeJoinToPure(i.StrokeJoin v) {
+  switch (v) {
+    case i.StrokeJoin.miter:
+      return p.StrokeJoin.miter;
+    case i.StrokeJoin.round:
+      return p.StrokeJoin.round;
+    case i.StrokeJoin.bevel:
+      return p.StrokeJoin.bevel;
+  }
+}
+
+i.StrokeJoin strokeJoinFromPure(p.StrokeJoin v) {
+  switch (v) {
+    case p.StrokeJoin.miter:
+      return i.StrokeJoin.miter;
+    case p.StrokeJoin.round:
+      return i.StrokeJoin.round;
+    case p.StrokeJoin.bevel:
+      return i.StrokeJoin.bevel;
+  }
+}
+
+p.FilterQuality filterQualityToPure(i.FilterQuality v) {
+  switch (v) {
+    case i.FilterQuality.none:
+      return p.FilterQuality.none;
+    case i.FilterQuality.low:
+      return p.FilterQuality.low;
+    case i.FilterQuality.medium:
+      return p.FilterQuality.medium;
+    case i.FilterQuality.high:
+      return p.FilterQuality.high;
+  }
+}
+
+i.FilterQuality filterQualityFromPure(p.FilterQuality v) {
+  switch (v) {
+    case p.FilterQuality.none:
+      return i.FilterQuality.none;
+    case p.FilterQuality.low:
+      return i.FilterQuality.low;
+    case p.FilterQuality.medium:
+      return i.FilterQuality.medium;
+    case p.FilterQuality.high:
+      return i.FilterQuality.high;
+  }
+}
+
+p.BlendMode blendModeToPure(i.BlendMode v) {
+  switch (v) {
+    case i.BlendMode.clear:
+      return p.BlendMode.clear;
+    case i.BlendMode.src:
+      return p.BlendMode.src;
+    case i.BlendMode.dst:
+      return p.BlendMode.dst;
+    case i.BlendMode.srcOver:
+      return p.BlendMode.srcOver;
+    case i.BlendMode.dstOver:
+      return p.BlendMode.dstOver;
+    case i.BlendMode.srcIn:
+      return p.BlendMode.srcIn;
+    case i.BlendMode.dstIn:
+      return p.BlendMode.dstIn;
+    case i.BlendMode.srcOut:
+      return p.BlendMode.srcOut;
+    case i.BlendMode.dstOut:
+      return p.BlendMode.dstOut;
+    case i.BlendMode.srcATop:
+      return p.BlendMode.srcATop;
+    case i.BlendMode.dstATop:
+      return p.BlendMode.dstATop;
+    case i.BlendMode.xor:
+      return p.BlendMode.xor;
+    case i.BlendMode.plus:
+      return p.BlendMode.plus;
+    case i.BlendMode.modulate:
+      return p.BlendMode.modulate;
+    case i.BlendMode.screen:
+      return p.BlendMode.screen;
+    case i.BlendMode.overlay:
+      return p.BlendMode.overlay;
+    case i.BlendMode.darken:
+      return p.BlendMode.darken;
+    case i.BlendMode.lighten:
+      return p.BlendMode.lighten;
+    case i.BlendMode.colorDodge:
+      return p.BlendMode.colorDodge;
+    case i.BlendMode.colorBurn:
+      return p.BlendMode.colorBurn;
+    case i.BlendMode.hardLight:
+      return p.BlendMode.hardLight;
+    case i.BlendMode.softLight:
+      return p.BlendMode.softLight;
+    case i.BlendMode.difference:
+      return p.BlendMode.difference;
+    case i.BlendMode.exclusion:
+      return p.BlendMode.exclusion;
+    case i.BlendMode.multiply:
+      return p.BlendMode.multiply;
+    case i.BlendMode.hue:
+      return p.BlendMode.hue;
+    case i.BlendMode.saturation:
+      return p.BlendMode.saturation;
+    case i.BlendMode.color:
+      return p.BlendMode.color;
+    case i.BlendMode.luminosity:
+      return p.BlendMode.luminosity;
+  }
+}
+
+p.ClipOp clipOpToPure(i.ClipOp v) {
+  switch (v) {
+    case i.ClipOp.difference:
+      return p.ClipOp.difference;
+    case i.ClipOp.intersect:
+      return p.ClipOp.intersect;
+  }
+}
+
+p.PathFillType pathFillTypeToPure(i.PathFillType v) {
+  switch (v) {
+    case i.PathFillType.nonZero:
+      return p.PathFillType.nonZero;
+    case i.PathFillType.evenOdd:
+      return p.PathFillType.evenOdd;
+  }
+}
+
+i.PathFillType pathFillTypeFromPure(p.PathFillType v) {
+  switch (v) {
+    case p.PathFillType.nonZero:
+      return i.PathFillType.nonZero;
+    case p.PathFillType.evenOdd:
+      return i.PathFillType.evenOdd;
+  }
+}
+
+p.PointMode pointModeToPure(i.PointMode v) {
+  switch (v) {
+    case i.PointMode.points:
+      return p.PointMode.points;
+    case i.PointMode.lines:
+      return p.PointMode.lines;
+    case i.PointMode.polygon:
+      return p.PointMode.polygon;
+  }
+}
+
+p.ImageByteFormat imageByteFormatToPure(i.ImageByteFormat v) {
+  switch (v) {
+    case i.ImageByteFormat.rawRgba:
+      return p.ImageByteFormat.rawRgba;
+    case i.ImageByteFormat.rawStraightRgba:
+      return p.ImageByteFormat.rawStraightRgba;
+    case i.ImageByteFormat.rawUnmodified:
+      return p.ImageByteFormat.rawUnmodified;
+    case i.ImageByteFormat.png:
+      return p.ImageByteFormat.png;
+    case i.ImageByteFormat.rawExtendedRgba128:
+      return p.ImageByteFormat.rawExtendedRgba128;
+  }
+}

--- a/packages/pure_ui_adapter/pubspec.yaml
+++ b/packages/pure_ui_adapter/pubspec.yaml
@@ -1,0 +1,14 @@
+name: pure_ui_adapter
+description: >-
+  Adapts the pure-Dart pure_ui implementation to the dart_ui_interface
+  UiBackend contract. Provides PureUiBackend, the default non-Flutter backend.
+version: 0.1.0
+publish_to: 'none'
+environment:
+  sdk: ^3.5.0
+resolution: workspace
+dependencies:
+  dart_ui_interface:
+  pure_ui:
+dev_dependencies:
+  test: ^1.24.0

--- a/packages/pure_ui_adapter/test/switching_test.dart
+++ b/packages/pure_ui_adapter/test/switching_test.dart
@@ -1,0 +1,76 @@
+import 'package:pure_ui/pure_ui.dart' as pure;
+import 'package:pure_ui_adapter/pure_ui_adapter.dart';
+import 'package:test/test.dart';
+
+/// A trivial backend used only to observe which backend `instance` resolves to.
+class _FakeBackend implements UiBackend {
+  @override
+  String get name => 'fake';
+  @override
+  bool supports(BackendFeature feature) => false;
+  @override
+  Paint createPaint() => throw UnimplementedError();
+  @override
+  Path createPath() => throw UnimplementedError();
+  @override
+  PictureRecorder createPictureRecorder() => throw UnimplementedError();
+  @override
+  Canvas createCanvas(PictureRecorder recorder, [Rect? cullRect]) =>
+      throw UnimplementedError();
+  @override
+  Future<Image> decodeImageFromPixels(
+          pixels, int width, int height, PixelFormat format) =>
+      throw UnimplementedError();
+  @override
+  Image createImageFromPixels(pixels, int width, int height) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  group('backend selection (§3.2)', () {
+    test('global instance is used by default', () {
+      UiBackend.instance = const PureUiBackend();
+      expect(UiBackend.instance.name, 'pure_ui');
+      expect(Paint(), isA<PureUiPaint>());
+    });
+
+    test('runWith overrides the global for its dynamic extent', () {
+      UiBackend.instance = const PureUiBackend();
+      final fake = _FakeBackend();
+      UiBackend.runWith(fake, () {
+        expect(UiBackend.instance.name, 'fake');
+      });
+      // Restored outside the zone.
+      expect(UiBackend.instance.name, 'pure_ui');
+    });
+
+    test('runWith nests', () {
+      UiBackend.instance = const PureUiBackend();
+      final fake = _FakeBackend();
+      UiBackend.runWith(fake, () {
+        expect(UiBackend.instance.name, 'fake');
+        UiBackend.runWith(const PureUiBackend(), () {
+          expect(UiBackend.instance.name, 'pure_ui');
+        });
+        expect(UiBackend.instance.name, 'fake');
+      });
+    });
+  });
+
+  group('pure_ui drop-in regression (§6.0)', () {
+    test('using pure_ui directly needs no backend and stays independent', () {
+      // The standalone pure_ui API must keep working with import-swap only.
+      // It never touches UiBackend, so it works even with no backend wired.
+      final recorder = pure.PictureRecorder();
+      final canvas =
+          pure.Canvas(recorder, const pure.Rect.fromLTWH(0, 0, 4, 4));
+      canvas.drawRect(
+        const pure.Rect.fromLTWH(0, 0, 4, 4),
+        pure.Paint()..color = const pure.Color(0xFF00FF00),
+      );
+      final picture = recorder.endRecording();
+      expect(picture.debugDisposed, isFalse);
+      picture.dispose();
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,19 @@ dev_dependencies:
   melos: any
 
 workspace:
-  - packages/*
+  - packages/pure_ui
+  - packages/dart_ui_interface
+  - packages/pure_ui_adapter
+  - packages/dart_ui_wrapper
+  - packages/dart_ui_conformance
 
 melos:
   packages:
     - packages/**
+  ignore:
+    # Flutter-only package: resolved with the Flutter SDK, not the Dart
+    # workspace. Kept out of `dart pub get` and the Dart-only CI path.
+    - packages/dart_ui_adapter
 
   command:
     bootstrap:


### PR DESCRIPTION
Implements `pure_ui_switching_architecture_plan.md`: write drawing code once and run it on either the Flutter engine (`dart:ui`) or `pure_ui`, switching by swapping a **single backend instance** — no import changes required.

## New packages (melos workspace)

| Package | Flutter | Role |
|---|:---:|---|
| `dart_ui_interface` | ✗ | concrete `const` value types, shared enums, `UiBackend` (global + Zone-scoped selection), factory-dispatching abstract resource types |
| `pure_ui_adapter` | ✗ | `PureUiBackend` — adapts the existing `pure_ui` engine (boundary value/enum conversion). Default backend |
| `dart_ui_wrapper` | ✗ | `ui.dart` drop-in surface + install/switch API |
| `dart_ui_adapter` | ✔ | `DartUiBackend` — adapts `dart:ui`. Only Flutter-dependent package; excluded from the Dart workspace |
| `dart_ui_conformance` | dev | backend-agnostic parity suite |

## Design decisions (per plan)
- **Value types are concrete & `const`** in the interface layer, never factory-dispatched (§1.3). Only resource types dispatch.
- **Adapter approach for pure_ui** (§2.1 option) keeps `pure_ui`'s standalone drop-in untouched (§6.0) — no 14k-line refactor.
- **Enums mapped with exhaustive switches**, never by index (§4.2).
- **Flutter isolated** to `dart_ui_adapter`; everything else resolves/tests with the Dart SDK only (§1.2). `dart_ui_adapter` is kept out of the workspace + melos so `dart pub get` needs no Flutter.
- **Unsupported features throw** `UnsupportedError`; `UiBackend.supports(...)` reports capability (§5).

## Verified green (Flutter-free)
- Drawing vertical slice end-to-end: `Paint`/`Path`/`Canvas`/`PictureRecorder`/`Picture`/`Image`, including rendering a rect to an image and reading pixels back.
- Backend switch mechanism: global / `runWith` / nested precedence.
- Value-type unit tests; pure_ui drop-in regression guard.
- Existing **268 pure_ui tests still pass** (no regression).

## Also included
- `docs/api_inventory.md` (P0 audit + coverage matrix) and `docs/switching_architecture.md`.
- Dart-only CI workflow with a guard forbidding direct `dart:ui` imports outside `dart_ui_adapter` (§6.3).
- README section.

## Not yet wired (horizontal expansion, scaffolded)
Text (`Paragraph*`), image codecs, shaders, and `*Filter` types — see the coverage matrix in `docs/api_inventory.md`. The `dart:ui` backend code is implemented but **unverified in this environment** (no Flutter SDK); run `cd packages/dart_ui_adapter && flutter test` to exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HB9PbU8zgAS4hb3XXadp6Z)_